### PR TITLE
Adding promise support, with examples

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -109,6 +109,24 @@
 });</pre>
 	</li>
 
+	<li class="using-promises">
+		<div class="ui">
+			<p>Chaining with promises.<br />Works on all modal types!</p>
+			<button>Try me!</button>
+		</div>
+		<pre>swal({
+&nbsp;&nbsp;title: <span class="str">"You're on your way!</span>",
+&nbsp;&nbsp;text: <span class="str">"What you do next is up to you.</span>",
+&nbsp;&nbsp;type: <span class="str">"success</span>",
+&nbsp;&nbsp;showCancelButton: <span class="val">true</span>
+	})
+	.then(<span class="func"><i>function</i></span>(){
+&nbsp;&nbsp;<span class="func">alert</span>(<span class="str">"Off we go!</span>");
+	}, <span class="func"><i>function</i></span>() { 
+&nbsp;&nbsp;<span class="func">alert</span>(<span class="str">"Dismissed!"</span>); 
+});</pre>
+	</li>
+
 </ul>
 
 
@@ -177,7 +195,7 @@
 	<tr>
 		<td><b>allowOutsideClick</b></td>
 		<td><i>false</i></td>
-		<td>If set to <strong>true</strong>, the user can dismiss the modal by clicking outside it.</td>
+		<td>If set to <strong>true</strong>, the user can dismiss the modal by clicking outside it.  Dismissal will reject the deferred.</td>
 	</tr>
 	<tr>
 		<td><b>showCancelButton</b></td>
@@ -253,6 +271,20 @@ $('ul.examples li.warning button').click(function(){
 	}, 
 	function(){
 		alert("Booyah!");
+	});
+});
+
+$('ul.examples li.using-promises button').click(function(){
+	swal({
+		title: "You're on your way!",
+		text: "What you do next is up to you.",
+		type: "success",
+		showCancelButton: true
+	})
+	.then(function(){
+		alert("Off we go!");
+	}, function () { 
+		alert("Dismissed!"); 
 	});
 });
 

--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -44,16 +44,17 @@
 
     // Default parameters
     var params = {
-      title: "",
-      text: "",
-      type: null,
-      allowOutsideClick: false,
-      showCancelButton: false,
-      confirmButtonText: "OK",
-      cancelButtonText: "Cancel",
-      imageUrl: null,
-      imageSize: null
-    };
+          title: "",
+          text: "",
+          type: null,
+          allowOutsideClick: true,
+          showCancelButton: false,
+          confirmButtonText: "OK",
+          cancelButtonText: "Cancel",
+          imageUrl: null,
+          imageSize: null
+        },
+        deferred = $.Deferred();
 
     if (arguments[0] === undefined) {
       window.console.error("sweetAlert expects at least 1 attribute!");
@@ -100,6 +101,10 @@
 
     }
 
+    deferred
+      .then(params.doneFunction)
+      .always(closeModal);
+
     setParameters(params);
     fixVerticalPosition();
     openModal();
@@ -112,23 +117,25 @@
           modalIsVisible      = $(modal).hasClass("visible"),
           doneFunctionExists  = params.doneFunction && $(modal).attr('data-has-done-function') === "true";
 
-      if (clickedOnConfirm && doneFunctionExists && modalIsVisible) {
-        params.doneFunction();
+      if (clickedOnConfirm) {
+        deferred.resolve();
+      } else {
+        deferred.reject();
       }
-      closeModal();
     });
 
-    $(document).click(function(e){ // Click outside
+    $('body').click(function(e){ // Click outside
       var clickedOnModal        = $(modal).is(e.target),
           clickedOnModalChild   = $(modal).has(e.target).length !== 0,
           modalIsVisible        = $(modal).hasClass("visible"),
           outsideClickIsAllowed = $(modal).attr('data-allow-ouside-click') === "true";
 
       if (!clickedOnModal && !clickedOnModalChild && modalIsVisible && outsideClickIsAllowed) {
-        closeModal();
+        deferred.reject();
       }
     });
 
+    return deferred.promise();
   };
 
   window.swal = window.sweetAlert; // Shorthand
@@ -226,10 +233,6 @@
 
     // Allow outside click?
     $(modal).attr('data-allow-ouside-click', params.allowOutsideClick);
-
-    // Done-function
-    var hasDoneFunction = (params.doneFunction) ? true : false;
-    $(modal).attr('data-has-done-function', hasDoneFunction);
   }
 
 


### PR DESCRIPTION
Confirmation action resolves the deferred, dismissal or cancel reject.

I find this to be really nice when working with client-side async workflows.  For example:

``` javascript`````
$.get('/some/endpoint')
    .then(function () {
        return swal({   
            title: "Success!",
            text: "You got /some/endpoint.  Want to fetch another?",
            type: "success",
            showCancelButton: true
        });
    })
    .then(function () {
        return $.get('/the/next/endpoint');
    })
    .then(goToNextPage);
```

Anyway, I consider promise support critical for any modal solution so I can compose messaging into my promise-based workflows!

Edit: I called out that dismiss right now rejects the deferred.  This is kind of an arbitrary decision and I am happy to make that resolve instead.  This could be made into a param option too.
