### PR TITLE
Confirm button background color can be changed

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -90,6 +90,7 @@
 &nbsp;&nbsp;text: <span class="str">"Click OK if you like living dangerously..."</span>,
 &nbsp;&nbsp;type: <span class="str">"warning"</span>,
 &nbsp;&nbsp;showCancelButton: <span class="val">true</span>,
+&nbsp;&nbsp;confirmButtonColor: <span class="str">"#98e069"</span>
 },
 <span class="func"><i>function</i></span>(){
 &nbsp;&nbsp;<span class="func">alert</span>(<span class="str">"Booyah!"</span>);
@@ -187,6 +188,11 @@
 		<td>Use this to change the text on the "Confirm"-button. If showCancelButton is set as true, the confirm button will automatically show "Confirm" instead of "OK".</td>
 	</tr>
 	<tr>
+		<td><b>confirmButtonColor</b></td>
+		<td><i>"#AEDEF4"</i></td>
+		<td>Use this to change the background color of the "Confirm"-button.</td>
+	</tr>
+	<tr>
 		<td><b>cancelButtonText</b></td>
 		<td><i>"Cancel"</i></td>
 		<td>Use this to change the text on the "Cancel"-button.</td>
@@ -247,6 +253,7 @@ document.querySelector('ul.examples li.warning button').onclick = function(){
 		text: "Click 'Confirm' if you like to live dangerously...",
 		type: "warning",
 		showCancelButton: true,
+		confirmButtonColor: '#98e069'
 	},
 	function(){
 		alert("Booyah!");

--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -154,6 +154,7 @@
       allowOutsideClick: false,
       showCancelButton: false,
       confirmButtonText: 'OK',
+      confirmButtonColor: '#AEDEF4',
       cancelButtonText: 'Cancel',
       imageUrl: null,
       imageSize: null
@@ -191,6 +192,7 @@
         }
 
         params.confirmButtonText = arguments[0].confirmButtonText || params.confirmButtonText;
+        params.confirmButtonColor = arguments[0].confirmButtonColor || params.confirmButtonColor;
         params.cancelButtonText = arguments[0].cancelButtonText || params.cancelButtonText;
         params.imageUrl = arguments[0].imageUrl || params.imageUrl;
         params.imageSize = arguments[0].imageSize || params.imageSize;
@@ -349,6 +351,8 @@
       $confirmBtn.innerHTML = escapeHtml(params.confirmButtonText);
     }
 
+    // Set confirm button to selected background color
+    $confirmBtn.style.backgroundColor = params.confirmButtonColor;
 
     // Allow outside click?
     modal.setAttribute('data-allow-ouside-click', params.allowOutsideClick);


### PR DESCRIPTION
I added an option called 'confirmButtonColor' that allows the user to change the background color of the confirm button (if there is one). I also updated the little docs so that it includes that option. I kept the default value to the current blueish color.
