### PR TITLE
adds bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,18 @@
+{
+  "name": "sweetalert",
+  "version": "0.0.0",
+  "homepage": "https://github.com/t4t5/sweetalert",
+  "description": "A beautiful replacement for JavaScript's \"alert\"",
+  "main": "lib/sweet-alert.js",
+  "authors": [
+    "Tristan Edwards <http://tristanedwards.me>"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Then use `bower register` to make this available via the bower package manager

```

Usage:

    bower register <name> <url> [<options>]
Options:

    -h, --help              Show this help message
    Additionally all global options listed in 'bower help' are available

Description:

    Registers a package.

```
