### PR TITLE
Fix bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "sweetalert",
-  "homepage": "http//tristanedwards.me/sweetalert",
+  "homepage": "http://tristanedwards.me/sweetalert",
   "authors": [
     "Tristan Edwards <tristan.edwards@me.com> (http://tristanedwards.me)"
   ],


### PR DESCRIPTION
Fix missing ':' in bower homepage.

Missing the ':' causes rails-assets.org to break when trying to build a gem from the project:

``` ruby
sweetalert#0.0.1: rake aborted!
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    "http//tristanedwards.me/sweetalert" is not a URI
/usr/local/rvm/gems/ruby-2.0.0-p481@global/gems/bundler-1.7.0/lib/bundler/gem_helper.rb:149:in `sh'
/usr/local/rvm/gems/ruby-2.0.0-p481@global/gems/bundler-1.7.0/lib/bundler/gem_helper.rb:57:in `build_gem'
/usr/local/rvm/gems/ruby-2.0.0-p481@global/gems/bundler-1.7.0/lib/bundler/gem_helper.rb:39:in `block in install'
Tasks: TOP => build
(See full trace by running task with --trace)
```
