### PR TITLE
Update Sweel Alert

### DIFF
--- a/lib/sweet-alert.scss
+++ b/lib/sweet-alert.scss
@@ -4,6 +4,12 @@
 
 @import url(http://fonts.googleapis.com/css?family=Open+Sans:400,600,700,300); // Open Sans font
 
+*{
+	-webkit-box-sizing: initial;
+	-moz-box-sizing: initial;
+	 box-sizing: initial;
+}
+
 .sweet-overlay {
 	background-color: rgba(black, 0.4);
 


### PR DESCRIPTION
I found a problem where Sweet Alert is not compatible with Bootstrap nor foundation because the \* class interferes with the box-sizing of the plugin.
