### PR TITLE
added content box-sizing to icons

### DIFF
--- a/lib/sweet-alert.css
+++ b/lib/sweet-alert.css
@@ -169,6 +169,7 @@
         height: 80px;
         border: 4px solid rgba(165, 220, 134, 0.2);
         border-radius: 50%;
+        box-sizing: content-box;
         position: absolute;
         left: -4px;
         top: -4px;

--- a/lib/sweet-alert.scss
+++ b/lib/sweet-alert.scss
@@ -230,6 +230,7 @@
 				height: 80px;
 				border: 4px solid rgba($green, 0.2);
 				border-radius: 50%;
+				box-sizing: content-box;
 
 				position: absolute;
 				left: -4px;


### PR DESCRIPTION
If you're using `box-sizing: border-box` on your page, sweetalert icons will show up like so:

![image](https://cloud.githubusercontent.com/assets/1147390/4516473/e805146a-4bf8-11e4-809a-43ba72749c11.png)

This PR adds explicit `box-sizing: content-box` to sweetalert icons.
