### PR TITLE
Set left position for warning icon dot to center it in IE

### DIFF
--- a/lib/sweet-alert.css
+++ b/lib/sweet-alert.css
@@ -114,6 +114,7 @@
         height: 7px;
         border-radius: 50%;
         margin-left: -3px;
+        left: 50%;
         bottom: 10px;
         background-color: #F8BB86; }
     .sweet-alert .icon.info {

--- a/lib/sweet-alert.scss
+++ b/lib/sweet-alert.scss
@@ -162,6 +162,7 @@
 				height: 7px;
 				border-radius: 50%;
 				margin-left: -3px;
+				left: 50%;
 				bottom: 10px;
 				background-color: $orange;
 			}


### PR DESCRIPTION
Fixes #42

Positioning is unchanged in Chrome and Firefox
