### PR TITLE
Wait until getModal returns the correct value

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -184,6 +184,23 @@
    */
 
   window.sweetAlert = window.swal = function() {
+    // Copy arguments to the local args variable
+    var args = arguments;
+    if (getModal() !== null) {
+        // If getModal returns values then continue
+        modalDependant.apply(this, args);
+    } else {
+        // If getModal returns null i.e. no matches, then set up a interval event to check the return value until it is not null	
+        var modalCheckInterval = setInterval(function() {
+          if (getModal() !== null) {
+            clearInterval(modalCheckInterval);
+            modalDependant.apply(this, args);
+          }
+      }, 100);
+    }
+  };
+        
+  function modalDependant() {
 
     // Default parameters
     var params = {


### PR DESCRIPTION
In response to https://github.com/t4t5/sweetalert/issues/53

the function is split to two swal and modalDependant

call getModal to see if it returns null or not, if it does return null then
start an interval with 100ms and check if it returns null until it does not return null and then call
the modalDependant() function, previously swal
