### PR TITLE
Make behaviour of Escape key press configurable. (Issue #65)

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -179,6 +179,11 @@
 		<td><i>null</i></td>
 		<td>The type of the modal. SweetAlert comes with 4 built-in types which will show a corresponding icon animation: "<strong>warning</strong>", "<strong>error</strong>", "<strong>success</strong>" and "<strong>info"</strong>. It can either be put in the array under the key "type" or passed as the third parameter of the function.</td>
 	</tr>
+        <tr>
+                <td><b>allowEscapeKey</b></td>
+                <td><i>true</i></td>
+                <td>If set to <strong>true</strong>, the user can dismiss the modal by pressing the Escape key.</td>
+        </tr>
 	<tr>
 		<td><b>allowOutsideClick</b></td>
 		<td><i>false</i></td>

--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -184,6 +184,19 @@
    */
 
   window.sweetAlert = window.swal = function() {
+    
+    /*
+     * Use argument if defined or default value from params object otherwise.
+     * Supports the case where a default value is boolean true and should be
+     * overridden by a corresponding explicit argument which is boolean false.
+     */
+    function argumentOrDefault(args, key) {
+      if (typeof args[key] !== 'undefined') {
+        return args[key];
+      } else {
+        return params[key];
+      }
+    }
 
     // Default parameters
     var params = {
@@ -191,6 +204,7 @@
       text: '',
       type: null,
       allowOutsideClick: false,
+      allowEscapeKey: true,
       showCancelButton: false,
       confirmButtonText: 'OK',
       confirmButtonColor: '#AEDEF4',
@@ -220,20 +234,21 @@
           return false;
         }
 
-        params.title              = arguments[0].title;
-        params.text               = arguments[0].text || params.text;
-        params.type               = arguments[0].type || params.type;
-        params.allowOutsideClick  = arguments[0].allowOutsideClick || params.allowOutsideClick;
-        params.showCancelButton   = arguments[0].showCancelButton || params.showCancelButton;
+        params.title              = argumentOrDefault(arguments[0], 'title');
+        params.text               = argumentOrDefault(arguments[0], 'text');
+        params.type               = argumentOrDefault(arguments[0], 'type');
+        params.allowOutsideClick  = argumentOrDefault(arguments[0], 'allowOutsideClick');
+        params.allowEscapeKey     = argumentOrDefault(arguments[0], 'allowEscapeKey');
+        params.showCancelButton   = argumentOrDefault(arguments[0], 'showCancelButton');
 
         // Show "Confirm" instead of "OK" if cancel button is visible
         params.confirmButtonText  = (params.showCancelButton) ? 'Confirm' : params.confirmButtonText;
 
-        params.confirmButtonText  = arguments[0].confirmButtonText || params.confirmButtonText;
-        params.confirmButtonColor = arguments[0].confirmButtonColor || params.confirmButtonColor;
-        params.cancelButtonText   = arguments[0].cancelButtonText || params.cancelButtonText;
-        params.imageUrl           = arguments[0].imageUrl || params.imageUrl;
-        params.imageSize          = arguments[0].imageSize || params.imageSize;
+        params.confirmButtonText  = argumentOrDefault(arguments[0], 'confirmButtonText');
+        params.confirmButtonColor = argumentOrDefault(arguments[0], 'confirmButtonColor');
+        params.cancelButtonText   = argumentOrDefault(arguments[0], 'cancelButtonText');
+        params.imageUrl           = argumentOrDefault(arguments[0], 'imageUrl');
+        params.imageSize          = argumentOrDefault(arguments[0], 'imageSize');
         params.doneFunction       = arguments[1] || null;
 
         break;
@@ -379,8 +394,7 @@
               // Do nothing - let the browser handle it.
               $targetElement = undefined;
             }
-        } else if (keyCode === 27 && !($cancelButton.hidden || $cancelButton.style.display === 'none')) {
-          // ESC to cancel only if there's a cancel button displayed (like the alert() window).
+        } else if (keyCode === 27 && params.allowEscapeKey === true) {
           $targetElement = $cancelButton;
         } else {
           // Fallback - let the browser handle it.


### PR DESCRIPTION
This change implements the proposal in issue #65:
A modal can be closed by pressing the Escape key, if the `allowEscapeKey` argument is set to `true`. This currently is the default.

This changes the previous default behaviour. Closing by pressing Escape can now be configured independently from displaying a Cancel button.

As the new default for this configuration option is `true`, the idiom

    option = argument || default

is not longer a viable solution for the application of arguments and default values (consider the case of using a default value of `true` and wanting to override it with `false`). Thus, a helper function `argumentOrDefault` was implemented and for better visual consistency the application of all arguments and default values was changed to use this new function.