### PR TITLE
Added a cool Input Field option for SweetAlert

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -99,6 +99,24 @@
 });</pre>
 	</li>
 
+	<li class="input">
+		<div class="ui">
+			<p>An information message that accepts an input text value and passes it to a function on confirmation</p>
+			<button>Try me!</button>
+		</div>
+		<pre>swal({
+	&nbsp;&nbsp;title: <span class="str">"Information"</span>,
+	&nbsp;&nbsp;text: <span class="str">"Please enter your first and last name"</span>,
+	&nbsp;&nbsp;type: <span class="str">"info"</span>,
+	&nbsp;&nbsp;showCancelButton: <span class="val">true</span>,
+	&nbsp;&nbsp;confirmButtonText: <span class="str">"Ok"</span>,
+	&nbsp;&nbsp;inputField: <span class="str">true</span>
+	},
+	<span class="func"><i>function</i></span>(){
+	&nbsp;&nbsp;<span class="func">alert</span>(<span class="str">"<user input value>"</span>);
+	});</pre>
+	</li>
+
 	<li class="custom-icon">
 		<div class="ui">
 			<p>A message with a custom icon</p>
@@ -214,6 +232,11 @@
 		<td><i>"80x80"</i></td>
 		<td>If imageUrl is set, you can specify imageSize to describes how big you want the icon to be in px. Pass in a string with two values separated by an "x". The first value is the width, the second is the height.</td>
 	</tr>
+	<tr>
+		<td><b>inputField</b></td>
+		<td><i>true</i></td>
+		<td>Set this value to true to have an input button present. The default value is false.</td>
+	</tr>
 </table>
 
 
@@ -261,10 +284,25 @@ document.querySelector('ul.examples li.warning button').onclick = function(){
 		type: "warning",
 		showCancelButton: true,
 		confirmButtonColor: '#DD6B55',
-		confirmButtonText: 'Yes, delete it!'
+		confirmButtonText: 'Yes, delete it!',
+		inputField: false
 	},
 	function(){
-		alert("Deleted!");
+		alert("Deleted!!");
+	});
+};
+
+document.querySelector('ul.examples li.input button').onclick = function(){
+	swal({
+		title: "Information",
+		text: "Please enter your first and last name",
+		type: "info",
+		showCancelButton: true,
+		confirmButtonText: 'Ok',
+		inputField: true
+	},
+	function(input){
+		alert(input);
 	});
 };
 

--- a/lib/sweet-alert.css
+++ b/lib/sweet-alert.css
@@ -47,7 +47,7 @@
     margin: 0;
     line-height: normal; }
   .sweet-alert button {
-    background-color: #AEDEF4;
+    background-color: #1B3F50;
     color: white;
     border: none;
     box-shadow: none;

--- a/lib/sweet-alert.css
+++ b/lib/sweet-alert.css
@@ -215,6 +215,18 @@
       border: none;
       background-position: center center;
       background-repeat: no-repeat; }
+    .sweet-alert .form-input {
+      text-align: left;
+      width: 200px;
+      height: 20px;
+      display: block;
+      margin : 0 auto;
+    }
+    .sweet-alert .input {
+      text-align: center;
+      padding-top: 10px;
+      margin-top: 10px;
+    }
 
 /*
  * Animations

--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -193,7 +193,7 @@
       allowOutsideClick: false,
       showCancelButton: false,
       confirmButtonText: 'OK',
-      confirmButtonColor: '#1B3F50',
+      confirmButtonColor: '#AEDEF4',
       cancelButtonText: 'Cancel',
       imageUrl: null,
       imageSize: null,

--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -159,7 +159,7 @@
    */
 
   function initialize() {
-    var sweetHTML = '<div class="sweet-overlay" tabIndex="-1"></div><div class="sweet-alert" tabIndex="-1"><div class="icon error"><span class="x-mark"><span class="line left"></span><span class="line right"></span></span></div><div class="icon warning"> <span class="body"></span> <span class="dot"></span> </div> <div class="icon info"></div> <div class="icon success"> <span class="line tip"></span> <span class="line long"></span> <div class="placeholder"></div> <div class="fix"></div> </div> <div class="icon custom"></div> <h2>Title</h2><p>Text</p><button class="cancel" tabIndex="2">Cancel</button><button class="confirm" tabIndex="1">OK</button></div>',
+    var sweetHTML = '<div class="sweet-overlay" tabIndex="-1"></div><div class="sweet-alert" tabIndex="-1"><div class="icon error"><span class="x-mark"><span class="line left"></span><span class="line right"></span></span></div><div class="icon warning"> <span class="body"></span> <span class="dot"></span> </div> <div class="icon info"></div> <div class="icon success"> <span class="line tip"></span> <span class="line long"></span> <div class="placeholder"></div> <div class="fix"></div> </div> <div class="icon custom"></div> <h2>Title</h2><p>Text</p><div class="input"><input type="text" value="" class="form-input"></input></div><button class="cancel" tabIndex="2">Cancel</button><button class="confirm" tabIndex="1">OK</button></div>',
         sweetWrap = document.createElement('div');
 
     sweetWrap.innerHTML = sweetHTML;
@@ -196,7 +196,8 @@
       confirmButtonColor: '#AEDEF4',
       cancelButtonText: 'Cancel',
       imageUrl: null,
-      imageSize: null
+      imageSize: null,
+      inputField: false
     };
 
     if (arguments[0] === undefined) {
@@ -234,6 +235,7 @@
         params.cancelButtonText   = arguments[0].cancelButtonText || params.cancelButtonText;
         params.imageUrl           = arguments[0].imageUrl || params.imageUrl;
         params.imageSize          = arguments[0].imageSize || params.imageSize;
+        params.inputField         = arguments[0].inputField || params.inputField;
         params.doneFunction       = arguments[1] || null;
 
         break;
@@ -295,7 +297,11 @@
           break;
         case ("click"):
           if (targetedConfirm && doneFunctionExists && modalIsVisible) {
-            params.doneFunction();
+            var $inputField = modal.querySelector("input.form-input")
+            var $inputFieldValue = $inputField.value
+            if(params.inputField && $inputField){
+              params.doneFunction($inputFieldValue);
+            } 
           }
           closeModal();
           break;
@@ -316,7 +322,6 @@
     previousDocumentClick = document.onclick;
     document.onclick = function(e) {
       var target = e.target || e.srcElement;
-
       var clickedOnModal = (modal === target),
           clickedOnModalChild = isDescendant(modal, e.target),
           modalIsVisible = hasClass(modal, 'visible'),
@@ -374,7 +379,9 @@
         if (keyCode === 13 || keyCode === 32) {
             if (btnIndex === -1) {
               // ENTER/SPACE clicked outside of a button.
-              $targetElement = $okButton;
+              if(!params.inputField){
+                $targetElement = $okButton;
+              }
             } else {
               // Do nothing - let the browser handle it.
               $targetElement = undefined;
@@ -429,14 +436,16 @@
 
     window.onfocus = function() {
       // When the user has focused away and focused back from the whole window.
-      window.setTimeout(function() {
-        // Put in a timeout to jump out of the event sequence. Calling focus() in the event
-        // sequence confuses things.
-        if (lastFocusedButton !== undefined) {
-          lastFocusedButton.focus();
-          lastFocusedButton = undefined;
-        }        
-      }, 0);
+      if(!params.inputField){
+        window.setTimeout(function() {
+          // Put in a timeout to jump out of the event sequence. Calling focus() in the event
+          // sequence confuses things.
+          if (lastFocusedButton !== undefined) {
+            lastFocusedButton.focus();
+            lastFocusedButton = undefined;
+          }        
+        }, 0);
+      }
     };
   };
 
@@ -451,7 +460,8 @@
     var $title = modal.querySelector('h2'),
         $text = modal.querySelector('p'),
         $cancelBtn = modal.querySelector('button.cancel'),
-        $confirmBtn = modal.querySelector('button.confirm');
+        $confirmBtn = modal.querySelector('button.confirm'),
+        $inputField = modal.querySelector('input.form-input');
 
     // Title
     $title.innerHTML = escapeHtml(params.title).split("\n").join("<br>");
@@ -526,6 +536,13 @@
         }
       }
       $customIcon.setAttribute('style', $customIcon.getAttribute('style') + 'width:' + _imgWidth + 'px; height:' + _imgHeight + 'px');
+    }
+
+    // Input Box
+    if(params.inputField){
+      $inputField.style.display = 'block';
+    } else {
+      hide($inputField);
     }
 
     // Cancel button
@@ -613,6 +630,12 @@
     setTimeout(function() {
       addClass(modal, 'visible');
     }, 500);
+
+    var inputField = modal.querySelector('input.form-input');
+    if(inputField){
+      inputField.focus();
+      inputField.value = "";
+    }
   }
 
   function closeModal() {

--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -193,7 +193,7 @@
       allowOutsideClick: false,
       showCancelButton: false,
       confirmButtonText: 'OK',
-      confirmButtonColor: '#AEDEF4',
+      confirmButtonColor: '#1B3F50',
       cancelButtonText: 'Cancel',
       imageUrl: null,
       imageSize: null,
@@ -301,7 +301,9 @@
             var $inputFieldValue = $inputField.value
             if(params.inputField && $inputField){
               params.doneFunction($inputFieldValue);
-            } 
+            } else {
+              params.doneFunction();
+            }
           }
           closeModal();
           break;


### PR DESCRIPTION
It is nice to have an input field for an alert to accept user input. I added the following features:

1) Added a parameter: inputField: (true | false) to enable the input field.
2) Added the necessary focus() to the input element programatically.
3) Updated the documentation to include the parameter and to include an example of a use case.

Update: I added an important fix that I missed on the first commit. That is the commit with the message: "Added fix for running params.doneFunction() without a parameter". Please include the head of master in the merge to get the latest changes.