### PR TITLE
Added success/cancel boolean parameter to callback

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -307,9 +307,7 @@
           } else if (doneFunctionExists && modalIsVisible) {
             params.doneFunction(false);
 
-            if(params.closeOnConfirm) {
-              closeModal();
-            }
+            closeModal();
           } else {
             closeModal();
           }


### PR DESCRIPTION
I've seen multiple pull requests adding an extra parameter for the cancel. But like @pomartel suggest on pull #18 , just passing `true` on accept, `false`, on cancel should be enough and cleaner.

So it would be like 

``` javascript
swal({
    title: "Are you sure?",
    text: "You will not be able to recover this imaginary file!",
    type: "warning",
    showCancelButton: true,
    confirmButtonColor: '#DD6B55',
    confirmButtonText: 'Yes, delete it!',
    closeOnConfirm: false
},
function(confirmed){
    if (confirmed){
        swal("Deleted!", "Your imaginary file has been deleted!", "success");
    } else {
        swal("Cancelled!", "Your imaginary file is safe!", "success");
    }

});
```
