### PR TITLE
IE9-10 compatibily. Wait until document.body is defined to initialize th...

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -678,7 +678,7 @@
    */
 
   (function () {
-	  if (document.readyState === "complete" || document.readyState === "interactive") {
+	  if (document.readyState === "complete" || document.readyState === "interactive" && document.body) {
 		  initialize();
 	  } else {
 		  if (document.addEventListener) {


### PR DESCRIPTION
IE9-10 compatibily. Wait until document.body is defined to initialize the library.
