### PR TITLE
Expose the initialize method

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -172,29 +172,6 @@
       lastFocusedButton;
 
   /*
-   * Add modal + overlay to DOM
-   */
-
-  window.sweetAlertInitialize = function() {
-    var sweetHTML = '<div class="sweet-overlay" tabIndex="-1"></div><div class="sweet-alert" tabIndex="-1"><div class="icon error"><span class="x-mark"><span class="line left"></span><span class="line right"></span></span></div><div class="icon warning"> <span class="body"></span> <span class="dot"></span> </div> <div class="icon info"></div> <div class="icon success"> <span class="line tip"></span> <span class="line long"></span> <div class="placeholder"></div> <div class="fix"></div> </div> <div class="icon custom"></div> <h2>Title</h2><p>Text</p><button class="cancel" tabIndex="2">Cancel</button><button class="confirm" tabIndex="1">OK</button></div>',
-        sweetWrap = document.createElement('div');
-
-    sweetWrap.innerHTML = sweetHTML;
-
-    // For readability: check sweet-alert.html
-    document.body.appendChild(sweetWrap);
-
-    // For development use only!
-    /*jQuery.ajax({
-      url: '../lib/sweet-alert.html', // Change path depending on file location
-      dataType: 'html'
-    })
-    .done(function(html) {
-      jQuery('body').append(html);
-    });*/
-  }
-
-  /*
    * Global sweetAlert function
    */
 
@@ -461,6 +438,28 @@
     };
   };
 
+  /*
+   * Add modal + overlay to DOM
+   */
+  window.swal.init = function() {
+    var sweetHTML = '<div class="sweet-overlay" tabIndex="-1"></div><div class="sweet-alert" tabIndex="-1"><div class="icon error"><span class="x-mark"><span class="line left"></span><span class="line right"></span></span></div><div class="icon warning"> <span class="body"></span> <span class="dot"></span> </div> <div class="icon info"></div> <div class="icon success"> <span class="line tip"></span> <span class="line long"></span> <div class="placeholder"></div> <div class="fix"></div> </div> <div class="icon custom"></div> <h2>Title</h2><p>Text</p><button class="cancel" tabIndex="2">Cancel</button><button class="confirm" tabIndex="1">OK</button></div>',
+        sweetWrap = document.createElement('div');
+
+    sweetWrap.innerHTML = sweetHTML;
+
+    // For readability: check sweet-alert.html
+    document.body.appendChild(sweetWrap);
+
+    // For development use only!
+    /*jQuery.ajax({
+      url: '../lib/sweet-alert.html', // Change path depending on file location
+      dataType: 'html'
+    })
+    .done(function(html) {
+      jQuery('body').append(html);
+    });*/
+  }
+
   /**
    * Set default params for each popup
    * @param {Object} userParams
@@ -723,23 +722,23 @@
    */
 
   (function () {
-	  if (document.readyState === "complete" || document.readyState === "interactive" && document.body) {
-		  sweetAlertInitialize();
-	  } else {
-		  if (document.addEventListener) {
-			  document.addEventListener('DOMContentLoaded', function factorial() {
-				  document.removeEventListener('DOMContentLoaded', arguments.callee, false);
-				  sweetAlertInitialize();
-			  }, false);
-		  } else if (document.attachEvent) {
-			  document.attachEvent('onreadystatechange', function() {
-				  if (document.readyState === 'complete') {
-					  document.detachEvent('onreadystatechange', arguments.callee);
-					  sweetAlertInitialize();
-				  }
-			  });
-		  }
-	  }
+    if (document.readyState === "complete" || document.readyState === "interactive" && document.body) {
+      swal.init();
+    } else {
+      if (document.addEventListener) {
+        document.addEventListener('DOMContentLoaded', function factorial() {
+          document.removeEventListener('DOMContentLoaded', arguments.callee, false);
+          swal.init();
+        }, false);
+      } else if (document.attachEvent) {
+        document.attachEvent('onreadystatechange', function() {
+          if (document.readyState === 'complete') {
+            document.detachEvent('onreadystatechange', arguments.callee);
+            swal.init();
+          }
+        });
+      }
+    }
   })();
 
 })(window, document);


### PR DESCRIPTION
As explained in https://github.com/t4t5/sweetalert/issues/76, Sweet Alert is incompatible with Turbolinks and other libraries that reload the content of the DOM. Exposing the initialize method fixes that.