### PR TITLE
Expose the Default Options

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -64,6 +64,14 @@
         _hide(elems[i]);
       }
     },
+    clone = function(obj) {
+        if (null == obj || "object" != typeof obj) return obj;
+        var copy = obj.constructor();
+        for (var attr in obj) {
+            if (obj.hasOwnProperty(attr)) copy[attr] = obj[attr];
+        }
+        return copy;
+    },
     isDescendant = function(parent, child) {
       var node = child.parentNode;
       while (node !== null) {
@@ -206,7 +214,7 @@
   window.sweetAlert = window.swal = function() {
 
     // Default parameters
-    var params = sweetAlertDefaultOptions;
+    var params = clone(sweetAlertDefaultOptions);
 
     if (arguments[0] === undefined) {
       window.console.error('sweetAlert expects at least 1 attribute!');


### PR DESCRIPTION
This is for the feature https://github.com/t4t5/sweetalert/issues/77. By exposing the default options, we let the users of the plugin change the default global settings. Here is an example to change the confirm button color globally:

```
$.extend(sweetAlertDefaultOptions, { confirmButtonColor: '#3B5998' });
```
