### PR TITLE
Allow \n to create line breaks

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -38,7 +38,7 @@
     escapeHtml = function(str) {
       var div = document.createElement('div');
       div.appendChild(document.createTextNode(str));
-      return div.innerHTML.replace( /\n/g, "<br>" );
+      return div.innerHTML.replace(/\n/g, '<br>');
     },
     _show = function(elem) {
       elem.style.opacity = '';

--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -38,7 +38,7 @@
     escapeHtml = function(str) {
       var div = document.createElement('div');
       div.appendChild(document.createTextNode(str));
-      return div.innerHTML;
+      return div.innerHTML.replace( /\n/g, "<br>" );
     },
     _show = function(elem) {
       elem.style.opacity = '';


### PR DESCRIPTION
In order to be a drop in replacement for javascript's alert function, you really need to allow /n in create line breaks. This change allows that.