### PR TITLE
Add requirejs support

### DIFF
--- a/example/index_requirejs.html
+++ b/example/index_requirejs.html
@@ -1,0 +1,368 @@
+<!DOCTYPE HTML>
+
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
+  <title>SweetAlert</title>
+
+  <link rel="stylesheet" href="./example.css">
+
+  <!-- This is what you need -->
+  <script src="http://requirejs.org/docs/release/2.1.15/minified/require.js"></script>
+  <link rel="stylesheet" href="../lib/sweet-alert.css">
+  <!--.......................-->
+
+</head>
+
+<body>
+
+<h1>Sweet Alert</h1>
+<h2>A beautiful replacement for Javascript's "Alert"</h2>
+<button class="download">Download</button>
+
+<!-- What does it do? -->
+<h3>So... What does it do?</h3>
+<p>Here’s a comparison of a standard error message. The first one uses the built-in <strong>alert</strong>-function, while the second is using <strong>sweetAlert</strong>.</p>
+
+<div class="showcase normal">
+	<h4>Normal alert</h4>
+	<button>Show error message</button>
+
+	<h5>Code:</h5>
+	<pre><span class="func">alert</span>(<span class="str">"Oops... Something went wrong!"</span>);
+
+	</pre>
+
+	<div class="vs-icon"></div>
+</div>
+
+<div class="showcase sweet">
+	<h4>Sweet Alert</h4>
+	<button>Show error message</button>
+
+	<h5>Code:</h5>
+	<pre>sweetAlert(<span class="str">"Oops..."</span>, <span class="str">"Something went wrong!"</span>, <span class="str">"error"</span>);</pre>
+</div>
+
+<p>Pretty cool huh? SweetAlert automatically centers itself on the page and looks great no matter if you're using a desktop computer, mobile or tablet. It's even highly customizeable, as you can see below!</p>
+
+
+<!-- Examples -->
+<h3>More examples</h3>
+
+<p class="center">In these examples, we're using the shorthand function <strong>swal</strong> to call sweetAlert.</p>
+
+<ul class="examples">
+
+	<li class="message">
+		<div class="ui">
+			<p>A basic message</p>
+			<button>Try me!</button>
+		</div>
+		<pre>swal(<span class="str">"Here's a message!"</span>)</pre>
+	</li>
+
+	<li class="title-text">
+		<div class="ui">
+			<p>A title with a text under</p>
+			<button>Try me!</button>
+		</div>
+		<pre>swal(<span class="str">"Here's a message!"</span>, <span class="str">"It's pretty, isn't it?"</span>)</pre>
+	</li>
+
+	<li class="success">
+		<div class="ui">
+			<p>A success message!</p>
+			<button>Try me!</button>
+		</div>
+		<pre>swal(<span class="str">"Good job!"</span>, <span class="str">"You clicked the button!"</span>, <span class="str">"success"</span>)</pre>
+	</li>
+
+	<li class="timer">
+		<div class="ui">
+			<p>A message with auto close timer</p>
+			<button>Try me!</button>
+		</div>
+		<pre>swal({
+&nbsp;&nbsp;title: <span class="str">"Auto close alert!"</span>,
+&nbsp;&nbsp;text: <span class="str">"I will close in 2 seconds."</span>,
+&nbsp;&nbsp;timer: <span class="str">2000</span>
+});</pre>
+	</li>
+
+	<li class="warning confirm">
+		<div class="ui">
+			<p>A warning message, with a function attached to the "Confirm"-button...</p>
+			<button>Try me!</button>
+		</div>
+		<pre>swal({
+&nbsp;&nbsp;title: <span class="str">"Are you sure?"</span>,
+&nbsp;&nbsp;text: <span class="str">"You will not be able to recover this imaginary file!"</span>,
+&nbsp;&nbsp;type: <span class="str">"warning"</span>,
+&nbsp;&nbsp;showCancelButton: <span class="val">true</span>,
+&nbsp;&nbsp;confirmButtonColor: <span class="str">"#DD6B55"</span>,
+&nbsp;&nbsp;confirmButtonText: <span class="str">"Yes, delete it!"</span>,
+&nbsp;&nbsp;closeOnConfirm: <span class="val">false</span>
+},
+<span class="func"><i>function</i></span>(){
+&nbsp;&nbsp;<span class="func">swal</span>(<span class="str">"Deleted!"</span>, <span class="str">"Your imaginary file has been deleted."</span>, <span class="str">"success"</span>);
+});</pre>
+	</li>
+
+	<li class="warning cancel">
+		<div class="ui">
+			<p>... and by passing a parameter, you can execute something else for "Cancel".</p>
+			<button>Try me!</button>
+		</div>
+		<pre>swal({
+&nbsp;&nbsp;title: <span class="str">"Are you sure?"</span>,
+&nbsp;&nbsp;text: <span class="str">"You will not be able to recover this imaginary file!"</span>,
+&nbsp;&nbsp;type: <span class="str">"warning"</span>,
+&nbsp;&nbsp;showCancelButton: <span class="val">true</span>,
+&nbsp;&nbsp;confirmButtonColor: <span class="str">"#DD6B55"</span>,
+&nbsp;&nbsp;confirmButtonText: <span class="str">"Yes, delete it!"</span>,
+&nbsp;&nbsp;cancelButtonText: <span class="str">"No, cancel plx!"</span>,
+&nbsp;&nbsp;closeOnConfirm: <span class="val">false</span>,
+&nbsp;&nbsp;closeOnCancel: <span class="val">false</span>
+},
+<span class="func"><i>function</i></span>(isConfirm){
+&nbsp;&nbsp;<span class="tag">if</span> (isConfirm) {
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="func">swal</span>(<span class="str">"Deleted!"</span>, <span class="str">"Your imaginary file has been deleted."</span>, <span class="str">"success"</span>);
+&nbsp;&nbsp;} <span class="tag">else</span> {
+	&nbsp;&nbsp;&nbsp;&nbsp;<span class="func">swal</span>(<span class="str">"Cancelled"</span>, <span class="str">"Your imaginary file is safe :)"</span>, <span class="str">"error"</span>);
+&nbsp;&nbsp;}
+});</pre>
+	</li>
+
+	<li class="custom-icon">
+		<div class="ui">
+			<p>A message with a custom icon</p>
+			<button>Try me!</button>
+		</div>
+		<pre>swal({
+&nbsp;&nbsp;title: <span class="str">"Sweet!"</span>,
+&nbsp;&nbsp;text: <span class="str">"Here's a custom image."</span>,
+&nbsp;&nbsp;imageUrl: <span class="str">"images/thumbs-up.jpg"</span>
+});</pre>
+	</li>
+
+</ul>
+
+
+<!-- Download & Install -->
+<h3 id="download-section">Download & install</h3>
+
+<div class="center-container">
+	<p class="center"><b>Method 1:</b> Install through bower:</p>
+	<pre class="center">$ bower install sweetalert</pre>
+</div>
+
+<p class="center"><b>Method 2:</b> Download the sweetAlert <strong>CSS</strong> and <strong>JavaScript</strong> files.</p>
+
+<a class="button" href="https://github.com/t4t5/sweetalert/archive/master.zip" download>Download files</a>
+
+<ol>
+	<li>
+		<p>Initialize the plugin by referencing the necessary files:</p>
+		<pre>&lt;<span class="tag">script</span> <span class="attr">src</span>=<span class="str">"lib/sweet-alert.min.js"</span>&gt;&lt;/<span class="tag">script</span>&gt;
+&lt;<span class="tag">link</span> <span class="attr">rel</span>=<span class="str">"stylesheet"</span> <span class="tag">type</span>=<span class="str">"text/css"</span> <span class="tag">href</span>=<span class="str">"lib/sweet-alert.css"</span>&gt;</pre>
+	</li>
+
+	<li>
+		<p>Call the sweetAlert-function after the page has loaded</p>
+		<pre>swal({
+&nbsp;&nbsp;title: <span class="str">"Error!"</span>,
+&nbsp;&nbsp;text: <span class="str">"Here's my error message!"</span>,
+&nbsp;&nbsp;type: <span class="str">"error"</span>,
+&nbsp;&nbsp;confirmButtonText: <span class="str">"Cool"</span>
+});
+</pre>
+	</li>
+</ol>
+
+
+
+<!-- Configuration -->
+<h3>Configuration</h3>
+
+<p class="center">Here are the keys that you can use if you pass an object into sweetAlert:</p>
+
+<table>
+	<tr class="titles">
+		<th>
+			<div class="border-left"></div>
+			Argument
+		</th>
+		<th>Default value</th>
+		<th>
+			<div class="border-right"></div>
+			Description
+		</th>
+	</tr>
+	<tr>
+		<td><b>title</b></td>
+		<td><i>null (required)</i></td>
+		<td>The title of the modal. It can either be added to the object under the key "title" or passed as the first parameter of the function.</td>
+	</tr>
+	<tr>
+		<td><b>text</b></td>
+		<td><i>null</i></td>
+		<td>A description for the modal. It can either be added to the object under the key "text" or passed as the second parameter of the function.</td>
+	</tr>
+	<tr>
+		<td><b>type</b></td>
+		<td><i>null</i></td>
+		<td>The type of the modal. SweetAlert comes with 4 built-in types which will show a corresponding icon animation: "<strong>warning</strong>", "<strong>error</strong>", "<strong>success</strong>" and "<strong>info"</strong>. It can either be put in the array under the key "type" or passed as the third parameter of the function.</td>
+	</tr>
+	<tr>
+		<td><b>allowOutsideClick</b></td>
+		<td><i>false</i></td>
+		<td>If set to <strong>true</strong>, the user can dismiss the modal by clicking outside it.</td>
+	</tr>
+	<tr>
+		<td><b>showCancelButton</b></td>
+		<td><i>false</i></td>
+		<td>If set to <strong>true</strong>, a "Cancel"-button will be shown, which the user can click on to dismiss the modal.</td>
+	</tr>
+	<tr>
+		<td><b>confirmButtonText</b></td>
+		<td><i>"OK"</i></td>
+		<td>Use this to change the text on the "Confirm"-button. If showCancelButton is set as true, the confirm button will automatically show "Confirm" instead of "OK".</td>
+	</tr>
+	<tr>
+		<td><b>confirmButtonColor</b></td>
+		<td><i>"#AEDEF4"</i></td>
+		<td>Use this to change the background color of the "Confirm"-button (must be a HEX value).</td>
+	</tr>
+	<tr>
+		<td><b>cancelButtonText</b></td>
+		<td><i>"Cancel"</i></td>
+		<td>Use this to change the text on the "Cancel"-button.</td>
+	</tr>
+	<tr>
+		<td><b>closeOnConfirm</b></td>
+		<td><i>true</i></td>
+		<td>Set to <i>false</i> if you want the modal to stay open even if the user presses the "Confirm"-button. This is especially useful if the function attached to the "Confirm"-button is another SweetAlert.</td>
+	</tr>
+	<tr>
+		<td><b>imageUrl</b></td>
+		<td><i>null</i></td>
+		<td>Add a customized icon for the modal. Should contain a string with the path to the image.</td>
+	</tr>
+	<tr>
+		<td><b>imageSize</b></td>
+		<td><i>"80x80"</i></td>
+		<td>If imageUrl is set, you can specify imageSize to describes how big you want the icon to be in px. Pass in a string with two values separated by an "x". The first value is the width, the second is the height.</td>
+	</tr>
+	<tr>
+		<td><b>timer</b></td>
+		<td><i>null</i></td>
+		<td>Auto close timer of the modal. Set in ms (milliseconds).</td>
+	</tr>
+</table>
+
+
+<!-- Contribute -->
+<h3>Contribute</h3>
+<p>SweetAlert was created by <a href="http://tristanedwards.me" target="_blank">Tristan Edwards</a>, you can follow him on <a href="https://twitter.com/t4t5" target="_blank" class="twitter">Twitter</a> or <a href="https://dribbble.com/tristanedwards" target="_blank" class="dribbble">Dribbble</a> for updates and other cool projects!</p>
+<p>Feel free to fork sweetAlert on <a href="https://github.com/t4t5/sweetalert" class="github">GitHub</a> if you have any features that you want to add!</p>
+
+
+<footer>
+	<span class="te-logo">TE</span> • 2014
+</footer>
+
+
+<script>
+
+require(['../lib/sweet-alert'], function(swal) {
+
+document.querySelector('button.download').onclick = function(){
+	$("html, body").animate({ scrollTop: $("#download-section").offset().top }, 1000);
+};
+
+document.querySelector('.showcase.normal button').onclick = function(){
+	alert("Oops... Something went wrong!");
+};
+
+document.querySelector('.showcase.sweet button').onclick = function(){
+	swal("Oops...", "Something went wrong!", "error");
+};
+
+document.querySelector('ul.examples li.message button').onclick = function(){
+	swal("Here's a message!");
+};
+
+document.querySelector('ul.examples li.timer button').onclick = function(){
+	swal({
+		title: "Auto close alert!",
+		text: "I will close in 2 seconds.",
+		timer: 2000
+	});
+};
+
+document.querySelector('ul.examples li.title-text button').onclick = function(){
+	swal("Here's a message!", "It's pretty, isn't it?")
+};
+
+document.querySelector('ul.examples li.success button').onclick = function(){
+	swal("Good job!", "You clicked the button!", "success");
+};
+
+document.querySelector('ul.examples li.warning.confirm button').onclick = function(){
+	swal({
+		title: "Are you sure?",
+		text: "You will not be able to recover this imaginary file!",
+		type: "warning",
+		showCancelButton: true,
+		confirmButtonColor: '#DD6B55',
+		confirmButtonText: 'Yes, delete it!',
+		closeOnConfirm: false,
+		//closeOnCancel: false
+	},
+	function(){
+		swal("Deleted!", "Your imaginary file has been deleted!", "success");
+	});
+};
+
+document.querySelector('ul.examples li.warning.cancel button').onclick = function(){
+	swal({
+		title: "Are you sure?",
+		text: "You will not be able to recover this imaginary file!",
+		type: "warning",
+		showCancelButton: true,
+		confirmButtonColor: '#DD6B55',
+		confirmButtonText: 'Yes, delete it!',
+		cancelButtonText: "No, cancel plx!",
+		closeOnConfirm: false,
+		closeOnCancel: false
+	},
+	function(isConfirm){
+    if (isConfirm){
+      swal("Deleted!", "Your imaginary file has been deleted!", "success");
+    } else {
+      swal("Cancelled", "Your imaginary file is safe :)", "error");
+    }
+	});
+};
+
+document.querySelector('ul.examples li.custom-icon button').onclick = function(){
+	swal({
+		title: "Sweet!",
+		text: "Here's a custom image.",
+		imageUrl: 'images/thumbs-up.jpg'
+	});
+};
+
+});
+
+</script>
+
+
+
+</body>
+
+</html>

--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -181,7 +181,7 @@
    * Add modal + overlay to DOM
    */
 
-  window.sweetAlertInitialize = function() {
+  var sweetAlertInitialize = function() {
     var sweetHTML = '<div class="sweet-overlay" tabIndex="-1"></div><div class="sweet-alert" tabIndex="-1"><div class="icon error"><span class="x-mark"><span class="line left"></span><span class="line right"></span></span></div><div class="icon warning"> <span class="body"></span> <span class="dot"></span> </div> <div class="icon info"></div> <div class="icon success"> <span class="line tip"></span> <span class="line long"></span> <div class="placeholder"></div> <div class="fix"></div> </div> <div class="icon custom"></div> <h2>Title</h2><p>Text</p><button class="cancel" tabIndex="2">Cancel</button><button class="confirm" tabIndex="1">OK</button></div>',
         sweetWrap = document.createElement('div');
 
@@ -195,7 +195,7 @@
    * Private sweetAlert function
    */
 
-  _swal = function() {
+  var swal = function() {
     if (arguments[0] === undefined) {
       window.console.error('sweetAlert expects at least 1 attribute!');
       return false;
@@ -465,7 +465,7 @@
    * Set default params for each popup
    * @param {Object} userParams
    */
-  window.swal.setDefaults = function(userParams) {
+  swal.setDefaults = function(userParams) {
     if (!userParams) {
       throw new Error('userParams is required');
     }
@@ -726,18 +726,18 @@
 
   (function () {
 	  if (document.readyState === "complete" || document.readyState === "interactive" && document.body) {
-		  window.sweetAlertInitialize();
+		  sweetAlertInitialize();
 	  } else {
 		  if (document.addEventListener) {
 			  document.addEventListener('DOMContentLoaded', function factorial() {
 				  document.removeEventListener('DOMContentLoaded', arguments.callee, false);
-				  window.sweetAlertInitialize();
+				  sweetAlertInitialize();
 			  }, false);
 		  } else if (document.attachEvent) {
 			  document.attachEvent('onreadystatechange', function() {
 				  if (document.readyState === 'complete') {
 					  document.detachEvent('onreadystatechange', arguments.callee);
-					  window.sweetAlertInitialize();
+					  sweetAlertInitialize();
 				  }
 			  });
 		  }
@@ -751,10 +751,10 @@
 
   if (typeof define === 'function' && define.amd) {
     define(function () {
-      return _swal;
+      return swal;
     });
   } else {
-    window.SweetAlert = window.swal = _swal;
+    window.SweetAlert = window.swal = swal;
   }
 
 })(window, document);

--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -192,10 +192,10 @@
   };
 
   /*
-   * Global sweetAlert function
+   * Private sweetAlert function
    */
 
-  window.sweetAlert = window.swal = function() {
+  _swal = function() {
     if (arguments[0] === undefined) {
       window.console.error('sweetAlert expects at least 1 attribute!');
       return false;
@@ -743,5 +743,18 @@
 		  }
 	  }
   })();
+
+  /*
+   * If an AMD loader is present, register the swal private function as an anonymous module.
+   * Else, declare it as global.
+   */
+
+  if (typeof define === 'function' && define.amd) {
+    define(function () {
+      return _swal;
+    });
+  } else {
+    window.SweetAlert = window.swal = _swal;
+  }
 
 })(window, document);


### PR DESCRIPTION
The example page (example/index.html) works as before (global swal & SweetAlert functions).
I added an example page using requirejs (example/index_requirejs.html), in which require.js is loaded instead of sweet-alert.js. When using the require function in the inline script tag, sweet-alert.js is loaded and the swal function is usable inside the require function. With requirejs loading, no sweet-alert function is declared globally.