### PR TITLE
Add custom HTML alert support

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -5,7 +5,7 @@
 
   var modalClass   = '.sweet-alert',
       overlayClass = '.sweet-overlay',
-      alertTypes   = ['error', 'warning', 'info', 'success'];
+      alertTypes   = ['error', 'warning', 'info', 'success', 'html'];
 
 
   /*
@@ -457,7 +457,12 @@
     $title.innerHTML = escapeHtml(params.title).split("\n").join("<br>");
 
     // Text
-    $text.innerHTML = escapeHtml(params.text || '').split("\n").join("<br>");
+    if (params.type != 'html') {
+      $text.innerHTML = escapeHtml(params.text || '').split("\n").join("<br>");  
+    } else {
+      $text.innerHTML = params.text || '';
+    }
+    
     if (params.text) {
       show($text);
     }
@@ -477,24 +482,26 @@
         return false;
       }
       var $icon = modal.querySelector('.icon.' + params.type);
-      show($icon);
+      if ($icon != undefined) {
+        show($icon);
 
-      // Animate icon
-      switch (params.type) {
-        case "success":
-          addClass($icon, 'animate');
-          addClass($icon.querySelector('.tip'), 'animateSuccessTip');
-          addClass($icon.querySelector('.long'), 'animateSuccessLong');
-          break;
-        case "error":
-          addClass($icon, 'animateErrorIcon');
-          addClass($icon.querySelector('.x-mark'), 'animateXMark');
-          break;
-        case "warning":
-          addClass($icon, 'pulseWarning');
-          addClass($icon.querySelector('.body'), 'pulseWarningIns');
-          addClass($icon.querySelector('.dot'), 'pulseWarningIns');
-          break;
+        // Animate icon
+        switch (params.type) {
+          case "success":
+            addClass($icon, 'animate');
+            addClass($icon.querySelector('.tip'), 'animateSuccessTip');
+            addClass($icon.querySelector('.long'), 'animateSuccessLong');
+            break;
+          case "error":
+            addClass($icon, 'animateErrorIcon');
+            addClass($icon.querySelector('.x-mark'), 'animateXMark');
+            break;
+          case "warning":
+            addClass($icon, 'pulseWarning');
+            addClass($icon.querySelector('.body'), 'pulseWarningIns');
+            addClass($icon.querySelector('.dot'), 'pulseWarningIns');
+            break;
+        }
       }
 
     }

--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -5,7 +5,7 @@
 
   var modalClass   = '.sweet-alert',
       overlayClass = '.sweet-overlay',
-      alertTypes   = ['error', 'warning', 'info', 'success', 'html'];
+      alertTypes   = ['error', 'warning', 'info', 'success'];
 
 
   /*
@@ -196,7 +196,8 @@
       confirmButtonColor: '#AEDEF4',
       cancelButtonText: 'Cancel',
       imageUrl: null,
-      imageSize: null
+      imageSize: null,
+      allowHtml: false
     };
 
     if (arguments[0] === undefined) {
@@ -235,6 +236,9 @@
         params.imageUrl           = arguments[0].imageUrl || params.imageUrl;
         params.imageSize          = arguments[0].imageSize || params.imageSize;
         params.doneFunction       = arguments[1] || null;
+
+        // Enable HTML dialog
+        params.allowHtml          = arguments[0].allowHtml;
 
         break;
 
@@ -457,7 +461,7 @@
     $title.innerHTML = escapeHtml(params.title).split("\n").join("<br>");
 
     // Text
-    if (params.type != 'html') {
+    if (!params.allowHtml) {
       $text.innerHTML = escapeHtml(params.text || '').split("\n").join("<br>");  
     } else {
       $text.innerHTML = params.text || '';


### PR DESCRIPTION
Add new alert type: **HTML**

**EDIT:** now using `allowHtml` option instead of `type`

This will allow creating HTML alert box, can be use to create custome dialog types, for example: Prompt, Date picker,...

Usage:

~~~javascript
swal({   
    title: "Custom dialog!",   
    text: "Here's my <b>HTML</b> <u>message</u>!",   
    type: "success",   
    confirmButtonText: "Yay!",
    allowHtml: true
});
~~~