### PR TITLE
[Feature] Allow config default params

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -6,7 +6,7 @@
   var modalClass   = '.sweet-alert',
       overlayClass = '.sweet-overlay',
       alertTypes   = ['error', 'warning', 'info', 'success'],
-      params = {
+      defaultParams = {
         title: '',
         text: '',
         type: null,
@@ -20,7 +20,6 @@
         imageUrl: null,
         imageSize: null
       };
-
 
 
   /*
@@ -204,6 +203,7 @@
       return false;
     }
 
+    var params = extend({}, defaultParams);
 
     switch (typeof arguments[0]) {
 
@@ -221,21 +221,21 @@
         }
 
         params.title              = arguments[0].title;
-        params.text               = arguments[0].text || params.text;
-        params.type               = arguments[0].type || params.type;
-        params.allowOutsideClick  = arguments[0].allowOutsideClick || params.allowOutsideClick;
-        params.showCancelButton   = arguments[0].showCancelButton !== undefined ? arguments[0].showCancelButton : params.showCancelButton;
-        params.closeOnConfirm     = arguments[0].closeOnConfirm !== undefined ? arguments[0].closeOnConfirm : params.closeOnConfirm;
-        params.closeOnCancel      = arguments[0].closeOnCancel !== undefined ? arguments[0].closeOnCancel : params.closeOnCancel;
+        params.text               = arguments[0].text || defaultParams.text;
+        params.type               = arguments[0].type || defaultParams.type;
+        params.allowOutsideClick  = arguments[0].allowOutsideClick || defaultParams.allowOutsideClick;
+        params.showCancelButton   = arguments[0].showCancelButton !== undefined ? arguments[0].showCancelButton : defaultParams.showCancelButton;
+        params.closeOnConfirm     = arguments[0].closeOnConfirm !== undefined ? arguments[0].closeOnConfirm : defaultParams.closeOnConfirm;
+        params.closeOnCancel      = arguments[0].closeOnCancel !== undefined ? arguments[0].closeOnCancel : defaultParams.closeOnCancel;
 
         // Show "Confirm" instead of "OK" if cancel button is visible
-        params.confirmButtonText  = (params.showCancelButton) ? 'Confirm' : params.confirmButtonText;
+        params.confirmButtonText  = (defaultParams.showCancelButton) ? 'Confirm' : defaultParams.confirmButtonText;
 
-        params.confirmButtonText  = arguments[0].confirmButtonText || params.confirmButtonText;
-        params.confirmButtonColor = arguments[0].confirmButtonColor || params.confirmButtonColor;
-        params.cancelButtonText   = arguments[0].cancelButtonText || params.cancelButtonText;
-        params.imageUrl           = arguments[0].imageUrl || params.imageUrl;
-        params.imageSize          = arguments[0].imageSize || params.imageSize;
+        params.confirmButtonText  = arguments[0].confirmButtonText || defaultParams.confirmButtonText;
+        params.confirmButtonColor = arguments[0].confirmButtonColor || defaultParams.confirmButtonColor;
+        params.cancelButtonText   = arguments[0].cancelButtonText || defaultParams.cancelButtonText;
+        params.imageUrl           = arguments[0].imageUrl || defaultParams.imageUrl;
+        params.imageSize          = arguments[0].imageSize || defaultParams.imageSize;
         params.doneFunction       = arguments[1] || null;
 
         break;
@@ -472,11 +472,7 @@
       throw new Error('userParams has to be a object');
     }
 
-    for (var prop in userParams) {
-      if (userParams.hasOwnProperty(prop)) {
-        params[prop] = userParams[prop];
-      }
-    }
+    extend(defaultParams, userParams);
   };
 
   /*
@@ -618,6 +614,16 @@
     }
 
     return rgb;
+  }
+
+  function extend(a, b){
+    for (var key in b) {
+      if (b.hasOwnProperty(key)) {
+        a[key] = b[key];
+      }
+    }
+
+    return a;
   }
 
   function hexToRgb(hex) {


### PR DESCRIPTION
This PR adds a method to `sweetAlert` for allow default params configuration, you only have to call the `setDefaults` method before call any `sweetAlert`, later each new popup will have the user config.
#### Usage

``` javascript
sweetAlert.setDefaults({
   allowOutsideClick: true,
   confirmButtonText: "Done"
});
```
