### PR TITLE
Dispatch event when initialized

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -169,6 +169,9 @@
     // For readability: check sweet-alert.html
     document.body.appendChild(sweetWrap);
 
+    var event = new CustomEvent( "swal:init", {detail: {wrap: sweetWrap}});
+    document.body.dispatchEvent(event);
+
     // For development use only!
     /*jQuery.ajax({
         url: '../lib/sweet-alert.html', // Change path depending on file location


### PR DESCRIPTION
Regarding https://github.com/t4t5/sweetalert/issues/124
Made an event "swal:init" that you can listen to in case you want to display the modal on document load, this way you can just put it in 
document.body.addEventListener("swal:init", function() { swal("Head", "Body") })