### PR TITLE
modal popup bug fix IE11

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -663,7 +663,7 @@
     }, 500);
 
     var timer = modal.getAttribute('data-timer');
-    if (timer !== "null") {
+    if (timer !== "null" && timer !== "") {
       setTimeout(function() {
         closeModal();
       }, timer);


### PR DESCRIPTION
checks for undefined timer as well as null timer, so that modal doesnt popup and disappear under IE 11