### PR TITLE
Import google fonts from html and not from css. Fixes #57 Closes #85

### DIFF
--- a/example/example.scss
+++ b/example/example.scss
@@ -1,6 +1,3 @@
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:400,600,700,300); // Open Sans font
-@import url(http://fonts.googleapis.com/css?family=Open+Sans+Condensed:700);   // Condensed
-
 @mixin retina-background($url, $type:png) {
   background-image: url("#{$url}.#{$type}");
   background-image: -webkit-image-set(url("#{$url}.#{$type}") 1x,
@@ -14,7 +11,7 @@ body {
 }
 
 h1 {
-  @include retina-background("images/logo_big"); 
+  @include retina-background("images/logo_big");
   width: 385px;
   height: 81px;
   text-indent: -9999px;
@@ -218,7 +215,7 @@ pre {
     height: 25px;
     margin-top: -3px;
     text-indent: -9999px;
-    @include retina-background("images/logo_small"); 
+    @include retina-background("images/logo_small");
   }
   h5 {
     margin-bottom: -7px;
@@ -330,7 +327,7 @@ table {
   text-align: left;
   border-collapse: collapse;
   @media all and (max-width: 750px) {
-    width: auto; 
+    width: auto;
     margin: 10px 20px;
   }
 

--- a/example/index.html
+++ b/example/index.html
@@ -8,6 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
   <title>SweetAlert</title>
 
+  <link href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700|Open+Sans+Condensed:700" rel="stylesheet" type="text/css">
   <link rel="stylesheet" href="./example.css">
 
   <!-- This is what you need -->

--- a/lib/sweet-alert.css
+++ b/lib/sweet-alert.css
@@ -1,4 +1,3 @@
-@import url(//fonts.googleapis.com/css?family=Open+Sans:400,600,700,300);
 .sweet-overlay {
   background-color: rgba(0, 0, 0, 0.4);
   position: fixed;

--- a/lib/sweet-alert.scss
+++ b/lib/sweet-alert.scss
@@ -2,8 +2,6 @@
 // 2014 (c) - Tristan Edwards
 // github.com/t4t5/sweetalert
 
-@import url(//fonts.googleapis.com/css?family=Open+Sans:400,600,700,300); // Open Sans font
-
 .sweet-overlay {
 	background-color: rgba(black, 0.4);
 


### PR DESCRIPTION
Just changed the place where the fonts are imported, this fixes some scenarios:

- When someone needs to use another font in their own project.
- Let the example show the google fonts.
- Allow someone to avoid the import call inside the css file, sometimes is bad when concatenating css files.