### PR TITLE
allow the option to not load Open Sans from Google APIs

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -9,6 +9,7 @@
       defaultParams = {
         title: '',
         text: '',
+        html: '',
         type: null,
         allowOutsideClick: false,
         showCancelButton: false,
@@ -223,6 +224,7 @@
 
         params.title              = arguments[0].title;
         params.text               = arguments[0].text || defaultParams.text;
+        params.html               = arguments[0].html || defaultParams.html;
         params.type               = arguments[0].type || defaultParams.type;
         params.allowOutsideClick  = arguments[0].allowOutsideClick || defaultParams.allowOutsideClick;
         params.showCancelButton   = arguments[0].showCancelButton !== undefined ? arguments[0].showCancelButton : defaultParams.showCancelButton;
@@ -493,9 +495,16 @@
 
     // Text
     $text.innerHTML = escapeHtml(params.text || '').split("\n").join("<br>");
-    if (params.text) {
-      show($text);
+    if (params.html) {
+      var $newDiv = document.createElement('div');
+      $newDiv.className = 'html';
+      $newDiv.innerHTML = params.html;
+      $text = $text.parentNode.replaceChild($newDiv, $text);
     }
+
+    if (params.text || params.html) {
+      show($text);
+    } 
 
     // Icon
     hide(modal.querySelectorAll('.icon'));

--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -690,8 +690,9 @@
     // Replace HTML with original <p>Text</p>
     var $html = modal.querySelector('.html'),
         $p = document.createElement('p');
-    $p.textContent = 'Text';
-    $html.parentNode.replaceChild($p, $html);
+    if ($html) {
+      $html.parentNode.replaceChild($p, $html);
+    }
 
     // Reset icon animations
     var $successIcon = modal.querySelector('.icon.success');

--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -687,9 +687,13 @@
     addClass(modal, 'hideSweetAlert');
     removeClass(modal, 'visible');
 
+    // Replace HTML with original <p>Text</p>
+    var $html = modal.querySelector('.html'),
+        $p = document.createElement('p');
+    $p.textContent = 'Text';
+    $html.parentNode.replaceChild($p, $html);
 
     // Reset icon animations
-
     var $successIcon = modal.querySelector('.icon.success');
     removeClass($successIcon, 'animate');
     removeClass($successIcon.querySelector('.tip'), 'animateSuccessTip');

--- a/lib/sweet-alert.scss
+++ b/lib/sweet-alert.scss
@@ -2,7 +2,11 @@
 // 2014 (c) - Tristan Edwards
 // github.com/t4t5/sweetalert
 
-@import url(//fonts.googleapis.com/css?family=Open+Sans:400,600,700,300); // Open Sans font
+$sweet-alert-load-fonts: true !default;
+
+@if $sweet-alert-load-fonts {
+	@import url("//fonts.googleapis.com/css?family=Open+Sans:400,600,700,300"); // Open Sans font
+}
 
 .sweet-overlay {
 	background-color: rgba(black, 0.4);


### PR DESCRIPTION
Our application loads Open Sans on its own accord, and so the request in the .scss file is redundant for us. Using the `!default` flag for this boolean means that, unless you specifically define `$sweet-alert-load-fonts`, nothing will change. 