### PR TITLE
Fix custom image size setting

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -545,8 +545,9 @@
           _imgHeight = 80;
 
       if (params.imageSize) {
-        var imgWidth  = params.imageSize.split('x')[0];
-        var imgHeight = params.imageSize.split('x')[1];
+        var dimensions = params.imageSize.toString().split('x');
+        var imgWidth  = dimensions[0];
+        var imgHeight = dimensions[1];
 
         if (!imgWidth || !imgHeight) {
           window.console.error("Parameter imageSize expects value with format WIDTHxHEIGHT, got " + params.imageSize);

--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -553,11 +553,6 @@
         } else {
           _imgWidth  = imgWidth;
           _imgHeight = imgHeight;
-
-          $customIcon.css({
-            'width': imgWidth + 'px',
-            'height': imgHeight + 'px'
-          });
         }
       }
       $customIcon.setAttribute('style', $customIcon.getAttribute('style') + 'width:' + _imgWidth + 'px; height:' + _imgHeight + 'px');


### PR DESCRIPTION
Currently if you use the imageSize property at all, you'll get an error when it tries to call .css() on $customIcon (as it isn't a jQuery object).