### PR TITLE
Added swal.cancelAlert() method that can be called globally to close the...

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -461,6 +461,13 @@
     };
   };
 
+   /*
+   * Cancel any existing sweet alerts
+   */
+   window.swal.cancelAlert = function() {
+     closeModal();
+   };
+
   /**
    * Set default params for each popup
    * @param {Object} userParams


### PR DESCRIPTION
... current modal with close animation.

Relevant Issue: #200 

This allows SweetAlerts to be used as a kind of busy "spinner" for AJAX request.

```
swal({
  title: "Searching...",
  text: "Click to cancel your search.",
  type: "info",
  showCancelButton: false,
  confirmButtonColor: "#DD6B55",
  confirmButtonText: "Cancel search",
  closeOnConfirm: true
});

$.ajax({
  url: "test.html",
  context: document.body
}).done(function() {
  // do something here 
  swal.cancelAlert()
});
```