### PR TITLE
Update example

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -303,7 +303,7 @@ document.querySelector('ul.examples li.timer button').onclick = function(){
 };
 
 document.querySelector('ul.examples li.title-text button').onclick = function(){
-	swal("Here's a message!", "It's pretty, isn't it?")
+	swal("Here's a message!", "It's pretty, isn't it?");
 };
 
 document.querySelector('ul.examples li.success button').onclick = function(){

--- a/example/index.html
+++ b/example/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+<!doctype html>
 
 <html>
 

--- a/example/index.html
+++ b/example/index.html
@@ -4,7 +4,6 @@
 
 <head>
   <meta charset="utf-8">
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
   <title>SweetAlert</title>
 


### PR DESCRIPTION
When I was reading through the example code, fixed 3 things:

* Fixed missing semicolon.
* A lowercase doctype is perfectly fine, and is more consistent with the other html code.
* A double charset declaration was included (the "old" way, and in https://github.com/t4t5/sweetalert/commit/f5cc61bd0bdf5b84889ae6e880ad1a3c53cfd15f @simonVansuyt included the "new" way).