### PR TITLE
Replace arguments.callee to function name

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -753,14 +753,14 @@
 		  window.sweetAlertInitialize();
 	  } else {
 		  if (document.addEventListener) {
-			  document.addEventListener('DOMContentLoaded', function factorial() {
-				  document.removeEventListener('DOMContentLoaded', arguments.callee, false);
+			  document.addEventListener('DOMContentLoaded', function handler() {
+				  document.removeEventListener('DOMContentLoaded', handler, false);
 				  window.sweetAlertInitialize();
 			  }, false);
 		  } else if (document.attachEvent) {
-			  document.attachEvent('onreadystatechange', function() {
+			  document.attachEvent('onreadystatechange', function handler() {
 				  if (document.readyState === 'complete') {
-					  document.detachEvent('onreadystatechange', arguments.callee);
+					  document.detachEvent('onreadystatechange', handler);
 					  window.sweetAlertInitialize();
 				  }
 			  });


### PR DESCRIPTION
Because an error in strict mode: "Uncaught TypeError: 'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them".