### PR TITLE
[FEATURE] Arrange modals in a stack so new ones don't overwrite old ones

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -377,7 +377,7 @@
             var functionHandlesCancel  = functionAsStr.substring(0, 9) === "function(" && functionAsStr.substring(9, 10) !== ")";
 
             if (functionHandlesCancel) {
-              params.doneFunction(false);
+            params.doneFunction(false);
             }
 
             if (params.closeOnCancel) {
@@ -492,7 +492,7 @@
     function handleOnBlur(event) {
       var e = event || window.event;
       var $targetElement = e.target || e.srcElement,
-          $focusElement = e.relatedTarget,
+          $focusElement = e.relatedTarget || e.toElement,
           modalIsVisible = hasClass(modal, 'visible');
 
       if (modalIsVisible) {

--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -6,6 +6,7 @@
   var modalClass   = '.sweet-alert',
       overlayClass = '.sweet-overlay',
       alertTypes   = ['error', 'warning', 'info', 'success'],
+      modalStack   = [],
       defaultParams = {
         title: '',
         text: '',
@@ -311,6 +312,7 @@
 
     }
 
+    modalStack.push(params);
     setParameters(params);
     fixVerticalPosition();
     openModal();
@@ -365,6 +367,8 @@
 
             if (params.closeOnConfirm) {
               window.sweetAlert.close();
+            } else {
+               modalStack.pop();
             }
           } else if (doneFunctionExists && modalIsVisible) { // Clicked "cancel"
 
@@ -378,6 +382,8 @@
 
             if (params.closeOnCancel) {
               window.sweetAlert.close();
+            } else {
+              modalStack.pop();
             }
           } else {
             window.sweetAlert.close();
@@ -753,6 +759,12 @@
 
   // Aninmation when closing modal
   window.sweetAlert.close = window.swal.close = function() {
+    modalStack.pop();
+    if (modalStack.length > 0) {
+      var last = modalStack.pop();
+      window.swal(last, last.doneFunction);
+      return;
+    }
     var modal = getModal();
     fadeOut(getOverlay(), 5);
     fadeOut(modal, 5);
@@ -787,6 +799,21 @@
     lastFocusedButton = undefined;
     clearTimeout(modal.timeout);
   };
+   
+  window.sweetAlert.closeMatching = function(title, text) {
+     var p = modalStack[modalStack.length-1];
+     if (p.title == title && (!text || p.text == text)) {
+        window.sweetAlert.close();
+        return;
+     }
+     for (var i = 0; i < modalStack.length; i++) {
+        p = modalStack[i];
+        if (p.title == title && (!text || p.text == text)) {
+           modalStack.splice(i,1);
+           return;
+        }
+     }
+  }
 
 
   /*


### PR DESCRIPTION
for example in the following after closing "3" you see "2" again, and after closing "2" you see "1" again:

   swal("1");
   setTimeout(function() { swal("2"); }, 2000);
   setTimeout(function() { swal("3"); }, 4000);

also adds window.sweetAlert.closeMatching() so you could close a dialog possibly in the middle of the stack