### PR TITLE
Allow title and text to add custom CSS classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ sweetAlert({
   confirmButtonColor: "#DD6B55",
   confirmButtonText: "Yes, delete it!",
   closeOnConfirm: false,
-  html: false
+  html: false,
+  titleCustomClass: 'myCustomSweetClasses sweetTitle',
+  textCustomClass: 'myCustomSweetClasses sweetText'
 }, function(){
   swal("Deleted!",
   "Your imaginary file has been deleted.",
@@ -91,4 +93,3 @@ to install the dependencies and make Gulp automatically minify the SCSS and JS-f
 * [SweetAlert for Android](https://github.com/pedant/sweet-alert-dialog)
 * [SweetAlert for Bootstrap](https://github.com/lipis/bootstrap-sweetalert)
 * [SweetAlert for AngularJS](https://github.com/oitozero/ngSweetAlert)
-

--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -23,7 +23,9 @@
         customClass: '',
         html: false,
         animation: true,
-        allowEscapeKey: true
+        allowEscapeKey: true,
+        titleCustomClass: false,
+        textCustomClass: false,
       };
 
 
@@ -287,7 +289,10 @@
           'imageSize',
           'html',
           'animation',
-          'allowEscapeKey'];
+          'allowEscapeKey',
+          'titleCustomClass',
+          'textCustomClass'
+        ];
 
         // It would be nice to just use .forEach here, but IE8... :(
         var numCustoms = availableCustoms.length;
@@ -557,11 +562,18 @@
         $cancelBtn = modal.querySelector('button.cancel'),
         $confirmBtn = modal.querySelector('button.confirm');
 
+
     // Title
     $title.innerHTML = (params.html) ? params.title : escapeHtml(params.title).split("\n").join("<br>");
+    if (params.titleCustomClass && ((typeof params.titleCustomClass) === 'string')) {
+      addClass($title, params.titleCustomClass);
+    }
 
     // Text
     $text.innerHTML = (params.html) ? params.text : escapeHtml(params.text || '').split("\n").join("<br>");
+    if (params.textCustomClass && ((typeof params.textCustomClass) === 'string')) {
+      addClass($text, params.textCustomClass);
+    }
 
     if (params.text) {
       show($text);


### PR DESCRIPTION
Parameter `titleCustomClass` adds a/some class(es) to the modal title.
Parameter `textCustomClass` adds a/some class(es) to the modal text
paragraph.

I needed that because I use a CSSLint validator that doesn't allow me to style h2 without class ; but it can help on many other customizations.