### PR TITLE
Fix dialog automatically closing in IE11

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -669,7 +669,9 @@
     }
 
     // Close timer
-    modal.setAttribute('data-timer', params.timer);
+    if (params.timer !== null) {
+      modal.setAttribute('data-timer', params.timer);
+    }
   }
 
 


### PR DESCRIPTION
When using `setAttribute` wil a value of `null`, the attribute will be set to an empty string.
So, when the attribute is later checked to be `!== null`, the result is unexpected and `closeModal()` will be called with a timeout of 0.

Fixes #279 
