### PR TITLE
Fixed bug in parameter 'allowOutsideClick'

### DIFF
--- a/lib/sweet-alert.js
+++ b/lib/sweet-alert.js
@@ -324,7 +324,8 @@
           targetedConfirm    = (target.className.indexOf("confirm") !== -1),
           targetedOverlay    = (target.className.indexOf("sweet-overlay") !== -1),
           modalIsVisible     = hasClass(modal, 'visible'),
-          doneFunctionExists = (params.doneFunction && modal.getAttribute('data-has-done-function') === 'true');
+          doneFunctionExists = (params.doneFunction && modal.getAttribute('data-has-done-function') === 'true'),
+          allowOutsideClick = (modal.getAttribute('data-allow-outside-click') === 'true');
 
       switch (e.type) {
         case ("mouseover"):
@@ -360,7 +361,7 @@
         case ("click"):
           if (targetedConfirm && doneFunctionExists && modalIsVisible) { // Clicked "confirm"
             handleConfirm();
-          } else if ((doneFunctionExists && modalIsVisible) || targetedOverlay) { // Clicked "cancel"
+          } else if ((doneFunctionExists && modalIsVisible) || (targetedOverlay && allowOutsideClick)) { // Clicked "cancel"
             handleCancel();
           } else if (isDescendant(modal, target) && target.tagName === "BUTTON") { 
             sweetAlert.close();
@@ -703,7 +704,7 @@
     }
 
     // Allow outside click?
-    modal.setAttribute('data-allow-ouside-click', params.allowOutsideClick);
+    modal.setAttribute('data-allow-outside-click', params.allowOutsideClick);
 
     // Done-function
     var hasDoneFunction = (params.doneFunction) ? true : false;


### PR DESCRIPTION
The name of the tag attribute was wrong ('data-allow-ouside-click' instead of 'data-allow-outside-click') and the parameter was not taken into account. This change should fix it.
