### PR TITLE
Fix typo in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ sweetAlert({
 A prompt modal where the user's input is logged:
 
 ```javascript
-sweerAlert({
+sweetAlert({
   title: "An input!",
   text: 'Write something interesting:',
   type: 'input',


### PR DESCRIPTION
Fix typo in code example so that users who copy the code won't see 
an error-Message because of a not defined sweerAlert-Function.