### PR TITLE
Add support for using HTML element as text parameter.

### DIFF
--- a/dev/modules/set-params.js
+++ b/dev/modules/set-params.js
@@ -36,7 +36,16 @@ var setParameters = function(params) {
   /*
    * Text
    */
-  $text.innerHTML = params.html ? params.text : escapeHtml(params.text || '').split('\n').join('<br>');
+  if (params.html) {
+    if (params.text instanceof HTMLElement) {
+      $text.innerHTML = '';
+      $text.appendChild(params.text);
+    } else {
+      $text.innerHTML = params.text;
+    }
+  } else {
+    $text.innerHTML = escapeHtml(params.text || '').split('\n').join('<br>');
+  }
   if (params.text) show($text);
 
   /*


### PR DESCRIPTION
I'm using Backbone and I'd really like to render a view into the `text` parameter, which would allow more advanced functionality inside the alert box.

I wasn't sure whether or not to include the compiled files, and when I compiled them the `sweetalert-dev.js` file was drastically changed, so I thought I wouldn't.

Thanks!
