### PR TITLE
Fixed: override the text align and floating.

### DIFF
--- a/lib/sweet-alert.css
+++ b/lib/sweet-alert.css
@@ -50,6 +50,8 @@
     position: relative;
     margin: 0;
     padding: 0;
+    text-align: inherit;
+    float: none;
     line-height: normal; }
   .sweet-alert button {
     background-color: #AEDEF4;


### PR DESCRIPTION
This issue has been raised when i had a css file which had such snippet

p{
float: right;
......
}

Signed-off-by: Alaa Attya Mohamed <vidooman@gmail.com>