### PR TITLE
Provider a commonjs entry point for webpack, browserify or any other commonjs module bundler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.DS_STORE
 node_modules
 bower_components
+lib

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,4 @@
-var gulp = require('gulp'); 
+var gulp = require('gulp');
 
 var glob       = require('glob');
 var path       = require('path');
@@ -14,6 +14,7 @@ var source     = require('vinyl-source-stream');
 var buffer     = require('vinyl-buffer');
 var wrap       = require('gulp-wrap');
 var qunit      = require('gulp-qunit');
+var babel      = require('gulp-babel');
 
 // Lint Task
 gulp.task('lint', function() {
@@ -58,6 +59,16 @@ themes.forEach(function(name) {
 
 gulp.task('themes', themes.map(function(name){ return name + '-theme'; }));
 
+// Compile ES5 CommonJS entry point
+gulp.task('commonjs', function() {
+  gulp.src('./dev/sweetalert.es6.js')
+    .pipe(babel())
+    .pipe(rename('sweetalert.js'))
+    .pipe(gulp.dest('lib'));
+  gulp.src('./dev/modules/*.js')
+    .pipe(babel())
+    .pipe(gulp.dest('lib/modules'));
+});
 
 // Concatenate & Minify JS
 gulp.task('scripts', function() {
@@ -94,4 +105,4 @@ gulp.task('watch', function() {
 });
 
 // Default Task
-gulp.task('default', ['lint', 'sass', 'scripts', 'watch', 'test']);
+gulp.task('default', ['lint', 'sass', 'scripts', 'commonjs', 'watch', 'test']);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sweetalert",
   "version": "1.1.0",
   "description": "A beautiful replacement for JavaScript's \"alert\"",
-  "main": "dist/sweetalert.min.js",
+  "main": "lib/sweetalert.js",
   "directories": {
     "example": "example"
   },
@@ -30,16 +30,17 @@
     "browserify": "^9.0.8",
     "glob": "^5.0.3",
     "gulp": "^3.9.0",
+    "gulp-babel": "^5.2.1",
     "gulp-concat": "^2.4.3",
     "gulp-jshint": "^1.9.0",
     "gulp-minify-css": "^0.3.13",
+    "gulp-qunit": "latest",
     "gulp-rename": "^1.2.0",
     "gulp-sass": "^2.0.1",
     "gulp-uglify": "^1.0.2",
     "gulp-wrap": "^0.11.0",
     "path": "^0.11.14",
     "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0",
-    "gulp-qunit": "latest"
+    "vinyl-source-stream": "^1.1.0"
   }
 }


### PR DESCRIPTION
- build js files from `es6` to `es5` into `lib` folder
- change `commonjs` entry point to `lib/sweetalert.js`

Fix #417 
@t4t5 
Please checkout this, thx!

If everything is ok, please merge and bump the version. Thanks for your great work on this lib.