### PR TITLE
Don't handle key events if theres no modal open.

### DIFF
--- a/dev/modules/handle-key.js
+++ b/dev/modules/handle-key.js
@@ -1,5 +1,5 @@
-import { stopEventPropagation, fireClick } from './handle-dom';
-import { setFocusStyle } from './handle-swal-dom';
+import { stopEventPropagation, fireClick, hasClass } from './handle-dom';
+import { setFocusStyle, getModal } from './handle-swal-dom';
 
 
 var handleKeyDown = function(event, params, modal) {
@@ -9,6 +9,12 @@ var handleKeyDown = function(event, params, modal) {
   var $okButton     = modal.querySelector('button.confirm');
   var $cancelButton = modal.querySelector('button.cancel');
   var $modalButtons = modal.querySelectorAll('button[tabindex]');
+
+  var $modal = getModal();
+
+  if (hasClass($modal, 'hideSweetAlert')) {
+    return;
+  }
 
 
   if ([9, 13, 32, 27].indexOf(keyCode) === -1) {


### PR DESCRIPTION
After opening (then closing) two modals at the same time, the TAB key stops working as expected.

``` javascript
swal('adsa'); swal('asdads');
// then click ok
```

This PR adds a check for a open modal before doing anything on the keydown event.
