### PR TITLE
Removed clear option that Internet Explorer puts in inputs.

### DIFF
--- a/dev/sweetalert.scss
+++ b/dev/sweetalert.scss
@@ -190,6 +190,9 @@ body.stop-scrolling {
     &::-moz-placeholder {
       color: lighten(#575757, 40);
     }
+    &::-ms-clear {
+      display: none;
+    }
     &:-ms-input-placeholder {
       color: lighten(#575757, 40);
     }

--- a/dist/sweetalert.css
+++ b/dist/sweetalert.css
@@ -152,6 +152,8 @@ body.stop-scrolling {
         opacity: 0.5; }
     .sweet-alert input::-moz-placeholder {
       color: #bdbdbd; }
+    .sweet-alert input::-ms-clear {
+      display: none; }
     .sweet-alert input:-ms-input-placeholder {
       color: #bdbdbd; }
     .sweet-alert input::-webkit-input-placeholder {


### PR DESCRIPTION
The red X from sweet alert clashes with the clear input from Internet Explorer.

![screen shot 2015-11-09 at 7 17 10 pm](https://cloud.githubusercontent.com/assets/2813592/11050803/45716662-8717-11e5-9e52-654a684b33ad.png)
