### PR TITLE
don't include padding when calculating margin

### DIFF
--- a/dev/sweetalert.scss
+++ b/dev/sweetalert.scss
@@ -37,7 +37,7 @@ body.stop-scrolling {
   position: fixed;
   left: 50%;
   top: 50%;
-  margin-left: -($width/2 + $padding);
+  margin-left: -($width/2);
   margin-top: -200px;
 
   overflow: hidden;


### PR DESCRIPTION
Our SweetAlert pops up over a similar-sized, centered box, and we noticed that it's actually a bit off-center:

![image](https://cloud.githubusercontent.com/assets/2231765/11101443/e7e9201a-8884-11e5-8c4d-b077296afe0a.png)

But, I found that setting the `margin-left` equal to half of the width made it centered:

![image](https://cloud.githubusercontent.com/assets/2231765/11101460/f9973478-8884-11e5-8550-7cbdca3d9167.png)

I think it makes sense, too. Since the padding is _inside_ the div's width, you don't need to account for it _again_ when calculating the margin.

What do you think? Have I missed something? Is this a good solution to the problem?
