### PR TITLE
Perfectly centered the sweet Alert, small change

### DIFF
--- a/dist/sweetalert.css
+++ b/dist/sweetalert.css
@@ -26,7 +26,7 @@ body.stop-scrolling {
   position: fixed;
   left: 50%;
   top: 50%;
-  margin-left: -256px;
+  margin-left: -239px;
   margin-top: -200px;
   overflow: hidden;
   display: none;


### PR DESCRIPTION
I modified the margin left of the sweet alert as it wasn't originally perfectly centered, and thus looked buggy on some pages, where u can clearly tell, so it has left:50%, right 50% , width 478px, but margin-left:-256px; which is not half of 478 so changed margin-left to -239px now perfectly centered.