### PR TITLE
Added Bootstrap support, so that sweet alert is properly centered

### DIFF
--- a/dist/sweetalert.css
+++ b/dist/sweetalert.css
@@ -26,7 +26,7 @@ body.stop-scrolling {
   position: fixed;
   left: 50%;
   top: 50%;
-  margin-left: -256px;
+  margin-left: -239px;
   margin-top: -200px;
   overflow: hidden;
   display: none;

--- a/dist/sweetalert.css
+++ b/dist/sweetalert.css
@@ -26,11 +26,16 @@ body.stop-scrolling {
   position: fixed;
   left: 50%;
   top: 50%;
-  margin-left: -239px;
+  margin-left: -256px;
   margin-top: -200px;
   overflow: hidden;
   display: none;
-  z-index: 99999; }
+  z-index: 99999;
+  /* Added this to make Sweet Alert Compatible with Bootstrap, because bootstrap
+  automatically adds box sizing to every element making the sweet-alert not centered*/
+  box-sizing: initial !important;
+  -webkit-box-sizing: initial !important;
+ }
   @media all and (max-width: 540px) {
     .sweet-alert {
       width: auto;


### PR DESCRIPTION
Bootstrap automatically adds box-sizing:border-box to every element, and this messes up the sweet alert making it no longer centered and off by 19px. This looks buggy on bootstrap based websites, thus, a little CSS code fix can fix this issue.
