### PR TITLE
Wrap fieldset in form to avoid Chrome iOS bug.

### DIFF
--- a/dev/modules/injected-html.js
+++ b/dev/modules/injected-html.js
@@ -37,10 +37,12 @@ var injectedHTML =
     // Title, text and input
     `<h2>Title</h2>
     <p>Text</p>
-    <fieldset>
-      <input type="text" tabIndex="3" />
-      <div class="sa-input-error"></div>
-    </fieldset>` +
+    <form>
+        <fieldset>
+          <input type="text" tabIndex="3" />
+          <div class="sa-input-error"></div>
+        </fieldset>
+    </form>` +
 
     // Input errors
     `<div class="sa-error-container">


### PR DESCRIPTION
Fixes #558 

Wraps fieldset in form tag to avoid "Can't find variable: fieldset" error from Chrome on iOS (https://bugs.chromium.org/p/chromium/issues/detail?id=570095)
