### PR TITLE
Allow thicker font when html alert includes strong or b tag

### DIFF
--- a/dev/sweetalert.scss
+++ b/dev/sweetalert.scss
@@ -77,6 +77,10 @@ body.stop-scrolling {
     margin: 0;
     padding: 0;
     line-height: normal;
+
+    b, strong {
+      font-weight: auto;
+    }
   }
 
   fieldset {


### PR DESCRIPTION
Hi!

Would be nice if one didn't need to specifically override the font-weight constraint set in sweetalert p, for <strong> & <b> elements.

Example:
![bold item in html alert information](https://cloud.githubusercontent.com/assets/1472950/14596713/bec07c38-0548-11e6-812a-1c8f9d1e3556.png)

Cheers!
