### PR TITLE
Fixed issue #573

### DIFF
--- a/dev/modules/handle-click.js
+++ b/dev/modules/handle-click.js
@@ -107,11 +107,10 @@ var handleConfirm = function(modal, params) {
  *  User clicked on "Cancel"
  */
 var handleCancel = function(modal, params) {
-  // Check if callback function expects a parameter (to track cancel actions)
-  var functionAsStr = String(params.doneFunction).replace(/\s/g, '');
-  var functionHandlesCancel = functionAsStr.substring(0, 9) === 'function(' && functionAsStr.substring(9, 10) !== ')';
+  // If the length is greater than 0, there is a method.
+  var hasArgumentsInDoneFunction = params.doneFunction.length;
 
-  if (functionHandlesCancel) {
+  if (hasArgumentsInDoneFunction) {
     params.doneFunction(false);
   }
 


### PR DESCRIPTION
The way to check whether or not a callback has an argument is not compatible with how Chrome and other new browsers render it.  The correct way is detailed here:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length

This is cross-browser compatible.
