### PR TITLE
Created external link on confirm option

### DIFF
--- a/dist/sweetalert-dev.js
+++ b/dist/sweetalert-dev.js
@@ -334,7 +334,9 @@ var defaultParams = {
   inputType: 'text',
   inputPlaceholder: '',
   inputValue: '',
-  showLoaderOnConfirm: false
+  showLoaderOnConfirm: false,
+  goToExternal: false,
+  externalUrl: ''
 };
 
 exports['default'] = defaultParams;
@@ -421,6 +423,9 @@ var handleButton = function handleButton(event, params, modal) {
         handleConfirm(modal, params);
       } else if (doneFunctionExists && modalIsVisible || targetedOverlay) {
         handleCancel(modal, params);
+      } else if (params.goToExternal && targetedConfirm) {
+        window.open(params.externalUrl, '_blank');
+        sweetAlert.close();
       } else if (_hasClass$isDescendant.isDescendant(modal, target) && target.tagName === 'BUTTON') {
         sweetAlert.close();
       }


### PR DESCRIPTION
I needed the Sweet Alert popup to explain some details and continue to an external website after the details have been displayed. I added this option in only the `dist/sweetalert-dev.js` file.
An example of the usage would be:

    $('#image-item').on('click', function(){
            swal({
                title: '<a href="http://www.externalwebsite.com" target="_blank">externalwebsite.com</a>',
                text: 'Here are some details about the website you're going to be visiting. It includes many unique things and it is a very cool website.',
                html: true,
                showCancelButton: true,
                allowOutsideClick: true,
                goToExternal: true,
                externalUrl: 'http://www.externalwebsite.com',
                confirmButtonText: "Continue"
            });
        });

Feel free to contact me with any comments or questions.