### PR TITLE
Added option for focus on Cancel button when modal opens.

### DIFF
--- a/dev/modules/default-params.js
+++ b/dev/modules/default-params.js
@@ -10,6 +10,7 @@ var defaultParams = {
   confirmButtonText: 'OK',
   confirmButtonColor: '#8CD4F5',
   cancelButtonText: 'Cancel',
+  cancelButtonFocus: false,
   imageUrl: null,
   imageSize: null,
   timer: null,

--- a/dev/modules/handle-key.js
+++ b/dev/modules/handle-key.js
@@ -30,7 +30,7 @@ var handleKeyDown = function(event, params, modal) {
     // TAB
     if (btnIndex === -1) {
       // No button focused. Jump to the confirm button.
-      $targetElement = $okButton;
+      $targetElement = params.cancelButtonFocus ? $cancelButton : $okButton;
     } else {
       // Cycle to the next button
       if (btnIndex === $modalButtons.length - 1) {
@@ -49,17 +49,18 @@ var handleKeyDown = function(event, params, modal) {
   } else {
     if (keyCode === 13) {
       if ($targetElement.tagName === 'INPUT') {
-        $targetElement = $okButton;
-        $okButton.focus();
+        $targetElement = params.cancelButtonFocus ? $cancelButton : $okButton;
+        $targetElement.focus();
       }
 
       if (btnIndex === -1) {
         // ENTER/SPACE clicked outside of a button.
-        $targetElement = $okButton;
+        $targetElement = params.cancelButtonFocus ? $cancelButton : $okButton;
       } else {
         // Do nothing - let the browser handle it.
-        $targetElement = undefined;
+        $targetElement = params.cancelButtonFocus ? $cancelButton : undefined;
       }
+
     } else if (keyCode === 27 && params.allowEscapeKey === true) {
       $targetElement = $cancelButton;
       fireClick($targetElement, e);

--- a/dev/modules/handle-swal-dom.js
+++ b/dev/modules/handle-swal-dom.js
@@ -62,7 +62,7 @@ var setFocusStyle = function($button, bgColor) {
 /*
  * Animation when opening modal
  */
-var openModal = function(callback) {
+var openModal = function(callback, cancelButtonFocus) {
   var $modal = getModal();
   fadeIn(getOverlay(), 10);
   show($modal);
@@ -71,7 +71,13 @@ var openModal = function(callback) {
 
   window.previousActiveElement = document.activeElement;
   var $okButton = $modal.querySelector('button.confirm');
-  $okButton.focus();
+  var $cancelButton = $modal.querySelector('button.cancel');
+  if(cancelButtonFocus) {
+    $cancelButton.focus();
+  } else {
+    $okButton.focus();
+  }
+
 
   setTimeout(function () {
     addClass($modal, 'visible');

--- a/dev/sweetalert.es6.js
+++ b/dev/sweetalert.es6.js
@@ -127,7 +127,7 @@ export default sweetAlert = swal = function() {
 
   setParameters(params);
   fixVerticalPosition();
-  openModal(arguments[1]);
+  openModal(arguments[1], params.cancelButtonFocus);
 
   // Modal interactions
   var modal = getModal();

--- a/index.html
+++ b/index.html
@@ -93,7 +93,8 @@
 &nbsp;&nbsp;showCancelButton: <span class="val">true</span>,
 &nbsp;&nbsp;confirmButtonColor: <span class="str">"#DD6B55"</span>,
 &nbsp;&nbsp;confirmButtonText: <span class="str">"Yes, delete it!"</span>,
-&nbsp;&nbsp;closeOnConfirm: <span class="val">false</span>
+&nbsp;&nbsp;closeOnConfirm: <span class="val">false</span>,
+&nbsp;&nbsp;cancelButtonFocus: <span class="val">true</span>
 },
 <span class="func"><i>function</i></span>(){
 &nbsp;&nbsp;<span class="attr">swal</span>(<span class="str">"Deleted!"</span>, <span class="str">"Your imaginary file has been deleted."</span>, <span class="str">"success"</span>);
@@ -331,6 +332,11 @@
 		<td><i>"Cancel"</i></td>
 		<td>Use this to change the text on the "Cancel"-button.</td>
 	</tr>
+  <tr>
+		<td><b>cancelButtonFocus</b></td>
+		<td><i>false</i></td>
+		<td>If set to <strong>true</strong>, the "Cancel"-button will have focus when the modal opens.</td>
+	</tr>
 	<tr>
 		<td><b>closeOnConfirm</b></td>
 		<td><i>true</i></td>
@@ -484,7 +490,8 @@ document.querySelector('ul.examples li.warning.confirm button').onclick = functi
 		showCancelButton: true,
 		confirmButtonColor: '#DD6B55',
 		confirmButtonText: 'Yes, delete it!',
-		closeOnConfirm: false
+		closeOnConfirm: false,
+		cancelButtonFocus: true
 	},
 	function(){
 		swal("Deleted!", "Your imaginary file has been deleted!", "success");
@@ -545,7 +552,7 @@ document.querySelector('ul.examples li.input button').onclick = function(){
 			swal.showInputError("You need to write something!");
 			return false;
 		}
-    
+
 		swal("Nice!", 'You wrote: ' + inputValue, "success");
 
 	});


### PR DESCRIPTION
Lovely component. The only thing missing was an option to give the Cancel button focus when the modal opens, in use cases where you don't want the user to accidentally hit ENTER and regret it. Please consider adding this.