### PR TITLE
fixes default for input elements

### DIFF
--- a/src/modules/init/content.ts
+++ b/src/modules/init/content.ts
@@ -30,12 +30,14 @@ const addInputEvents = (input: HTMLElement): void => {
 
   /*
    * FIXME (this is a bit hacky)
-   * We're overwriting the default value of confirm button,
-   * as well as overwriting the default focus on the button
+   * Set the focus to the input
+   * Overwrite the submit value with the 
+   * value of the input element ("" or value/defaultValue)
    */
   setTimeout(() => {
     input.focus();
-    setActionValue('');
+    const defaultValue = (input as HTMLInputElement).value;
+    setActionValue(defaultValue)
   }, 0);
 
 };


### PR DESCRIPTION
- Fixes: #764: Input returns empty string if defaultValue not changed
- Now the return value is initialized to the value of the input element
  - This is STILL an empty string `""` if no default value is supplied
  - If default value is `hello world`, submitting the swal will now return `hello world`

![image](https://user-images.githubusercontent.com/9692067/32984022-3aaea626-cc6c-11e7-9e03-2ff3b5cd38d9.png)
