### PR TITLE
Automatically replace \n with <br>

### DIFF
--- a/src/modules/init/text.ts
+++ b/src/modules/init/text.ts
@@ -11,7 +11,7 @@ import { injectElIntoModal } from './modal';
  * https://stackoverflow.com/a/3485654/2679245
  */
 const webkitRerender = (el: HTMLElement) => {
-  if (navigator.userAgent.includes('AppleWebKit')){
+  if (navigator.userAgent.includes('AppleWebKit')) {
     el.style.display = 'none';
     el.offsetHeight;
     el.style.display = '';
@@ -29,8 +29,17 @@ export const initTitle = (title: string): void => {
 
 export const initText = (text: string): void => {
   if (text) {
+    let textNode = document.createDocumentFragment();
+    text.split('\n').forEach((textFragment, index, array) => {
+      textNode.appendChild(document.createTextNode(textFragment));
+
+      // unless we are on the last element, append a <br>
+      if (index < array.length - 1) {
+        textNode.appendChild(document.createElement('br'));
+      }
+    });
     const textEl: HTMLElement = injectElIntoModal(textMarkup);
-    textEl.textContent = text;
+    textEl.appendChild(textNode);
 
     webkitRerender(textEl);
   }

--- a/test/content.test.ts
+++ b/test/content.test.ts
@@ -1,12 +1,14 @@
 import {
   swal,
   removeSwal,
+  $,
   $$,
   CLASS_NAMES,
 } from './utils';
 
-const { 
+const {
   CONTENT,
+  MODAL_TEXT
 } = CLASS_NAMES;
 
 afterEach(() => removeSwal());
@@ -64,3 +66,18 @@ describe("show content", () => {
 
 });
 
+describe("show modal text", () => {
+  test("transforms newline to break", () => {
+    swal('Hello\nWorld\n');
+
+    expect($(`.${MODAL_TEXT} br`).length).toBe(2);
+  });
+
+  test("escapes HTML elements", () => {
+    const text = '<script>bad stuff</script>';
+    swal(text);
+
+    expect($(`.${MODAL_TEXT} script`).length).toBe(0);
+    expect($$(MODAL_TEXT).text()).toEqual(expect.stringMatching(text));
+  });
+});


### PR DESCRIPTION
This closes #740 and #770 as it transforms `\n` to `<br>` tags when used like this:
```js
swal('Hello\nWorld');
```

Implementation might look a little funky, but I wanted to stay away from `.innerHTML`.

Also: tests 😁