### PR TITLE
FIX: Windows Scrollbars

### DIFF
--- a/docs/assets/css/highlight.css
+++ b/docs/assets/css/highlight.css
@@ -4,7 +4,7 @@
   font-size: 14px;
   line-height: normal;
   color: rgba(0,0,0,0.62);
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 .highlight .editor {
   font-family: $code-font;

--- a/src/sweetalert.css
+++ b/src/sweetalert.css
@@ -16,7 +16,7 @@
   right: 0;
   text-align: center;
   font-size: 0; /* Remove gap between inline-block elements */
-  overflow-y: scroll;
+  overflow-y: auto;
 
   background-color: rgba(0, 0, 0, 0.4);
   z-index: 10000;
@@ -31,7 +31,7 @@
   }
 
   &--show-modal {
-    opacity: 1; 
+    opacity: 1;
     pointer-events: auto;
 
     & .swal-modal {


### PR DESCRIPTION
On windows, overflow scroll always shows scroll-bars which are hideous, `auto` must be used to be hidden when not needed.

With `overflow-y: scroll;`

![image](https://user-images.githubusercontent.com/2953026/33443623-bf762df0-d600-11e7-9fc6-d9bbce5d031b.png)

There are 2 scrollbars on the right, vs:

![image](https://user-images.githubusercontent.com/2953026/33443684-d9f35504-d600-11e7-895a-96089fd34dad.png)

just one with `overflow-y: auto;`

------

Same goes with the code examples:
![image](https://user-images.githubusercontent.com/2953026/33443740-fceca0ce-d600-11e7-9a59-4589cf19dbd7.png)

![image](https://user-images.githubusercontent.com/2953026/33443750-073700ba-d601-11e7-9aac-197e3a37b27f.png)


-----

With a lot of text, it works as expected:

![image](https://user-images.githubusercontent.com/2953026/33443897-6ce2cc50-d601-11e7-8041-b247c12fc445.png)


