### PR TITLE
Namespace is optional.

### DIFF
--- a/typings/core.d.ts
+++ b/typings/core.d.ts
@@ -3,7 +3,7 @@ import { SwalOptions } from './modules/options';
 export declare type SwalParams = (string | Partial<SwalOptions>)[];
 export interface SweetAlert {
     (...params: SwalParams): Promise<any>;
-    close?(namespace: string): void;
+    close?(namespace?: string): void;
     getState?(): SwalState;
     setActionValue?(opts: string | ActionOptions): void;
     stopLoading?(): void;


### PR DESCRIPTION
Namespace is optional. Right now calling swal.close() gives error in typescript.