### PR TITLE
Set namespace definition to be optional

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -29,7 +29,7 @@ export type SwalParams = (string|Partial<SwalOptions>)[];
 
 export interface SweetAlert {
   (...params: SwalParams): Promise<any>,
-  close? (namespace: string): void,
+  close? (namespace?: string): void,
   getState? (): SwalState,
   setActionValue? (opts: string|ActionOptions): void,
   stopLoading? (): void,
@@ -63,4 +63,3 @@ swal.stopLoading = stopLoading;
 swal.setDefaults = setDefaults;
 
 export default swal;
-


### PR DESCRIPTION
When building the project the definition of namespace parameter for the function close under typing will change to be required because in #802 the generated file was changed it, but not the actual code, this should fix this.