### PR TITLE
Fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ swal("Oops!", "Something went wrong!", "error")
 
 ## Contributors
 
-This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
-<a href="graphs/contributors"><img src="https://opencollective.com/SweetAlert/contributors.svg?width=890&button=false" /></a>
+This project exists thanks to all the people who contribute. [[Contribute](https://github.com/t4t5/sweetalert#contributing)].
+<a href="https://github.com/t4t5/sweetalert/graphs/contributors"><img src="https://opencollective.com/SweetAlert/contributors.svg?width=890&button=false" /></a>
 
 
 ## Backers


### PR DESCRIPTION
* Since we don't have a CONTRIBUTING.md (yet?), I linked to the section in the README directly.
* Also made the links absolute so they point to github.com, even when accessed from npmjs.com for instance.