### PR TITLE
error fixed for swal to _swal for angular 7 & above

### DIFF
--- a/src/sweetalert.d.ts
+++ b/src/sweetalert.d.ts
@@ -1,7 +1,7 @@
 import swal, { SweetAlert } from "./core";
 
 declare global {
-  const swal: SweetAlert;
+  const _swal: SweetAlert;
   const sweetAlert: SweetAlert;
 }
 


### PR DESCRIPTION
### **Error fixed for the following error on angular**
`ERROR in node_modules/SweetAlert/typings/sweetalert.d.ts:4:10 - error TS2403: Subsequent variable declarations must have the same type.  Variable 'swal' must be of type 'typeof import("E:/projects/New folder/certistore/node_modules/SweetAlert/typings/sweetalert")', but here has type 'SweetAlert'.

4    const swal: SweetAlert;
           ~~~~

  node_modules/SweetAlert/typings/sweetalert.d.ts:1:1
    1 import swal, { SweetAlert } from "./core";
      ~~~~~~
    'swal' was also declared here.`