### PR TITLE
fixing swal constant error

### DIFF
--- a/typings/sweetalert.d.ts
+++ b/typings/sweetalert.d.ts
@@ -1,7 +1,7 @@
 import swal, { SweetAlert } from "./core";
 
 declare global {
-  const swal: SweetAlert;
+  const _swal_: SweetAlert;
   const sweetAlert: SweetAlert;
 }
 


### PR DESCRIPTION
I'm fixing this issue:

ERROR in node_modules/sweetalert/typings/sweetalert.d.ts:4:9 - error TS2403: Subsequent variable declarations must have the same type. Variable 'swal' must be of type 'typeof import("/Users/juan/bookifiweb/node_modules/sweetalert/typings/sweetalert")', but here has type 'SweetAlert'.

4 const swal: SweetAlert;
~~~~

node_modules/sweetalert/typings/sweetalert.d.ts:1:1
1 import swal, { SweetAlert } from "./core";
~~~~~~
'swal' was also declared here


by changing the swal name

