### PR TITLE
fix: respect animation:false option to disable modal animations

### DIFF
--- a/src/modules/init/modal.ts
+++ b/src/modules/init/modal.ts
@@ -35,10 +35,14 @@ const resetModalElement = (modal: Element): void => {
 const customizeModalElement = (modal: Element, opts: SwalOptions): void => {
   resetModalElement(modal);
 
-  const { className } = opts;
+  const { className, animation } = opts;
 
   if (className) {
     modal.classList.add(className);
+  }
+
+  if (animation === false) {
+    modal.classList.add('swal-modal--no-animation');
   }
 };
 

--- a/src/modules/options/deprecations.ts
+++ b/src/modules/options/deprecations.ts
@@ -83,7 +83,6 @@ export const DEPRECATED_OPTS: OptionReplacementsList = {
   'showLoaderOnConfirm': {
     replacement: 'buttons',
   },
-  'animation': {},
   'inputType': {
     replacement: 'content',
     link: '/docs/#content',

--- a/src/modules/options/index.ts
+++ b/src/modules/options/index.ts
@@ -37,6 +37,7 @@ export interface SwalOptions {
   closeOnEsc: boolean,
   dangerMode: boolean,
   timer: number,
+  animation: boolean,
 };
 
 const defaultOpts: SwalOptions = {
@@ -50,6 +51,7 @@ const defaultOpts: SwalOptions = {
   closeOnEsc: true,
   dangerMode: false,
   timer: null,
+  animation: true,
 };
 
 /*

--- a/src/sweetalert.css
+++ b/src/sweetalert.css
@@ -41,6 +41,10 @@
       animation: showSweetAlert 0.3s;
       will-change: transform;
     }
+
+    & .swal-modal.swal-modal--no-animation {
+      animation: none;
+    }
   }
 }
 
@@ -112,4 +116,15 @@ Target IE8-IE10 due to incompability with the css `pointer-event` property.
   .swal-modal {
     visibility: hidden;
   }
+}
+
+/* Disable animation when animation option is false */
+.swal-overlay--show-modal .swal-modal.swal-modal--no-animation {
+  animation: none;
+}
+
+.swal-modal--no-animation .swal-icon--success__line,
+.swal-modal--no-animation .swal-icon--error__x-mark,
+.swal-modal--no-animation .swal-icon--warning {
+  animation: none;
 }


### PR DESCRIPTION
## Fixes #1010

### Problem
Setting `animation: false` in SweetAlert options had no effect. The bounce/fade animation always played because it was hardcoded in CSS with no way to disable it.

### Solution
- Added `animation` as a proper `SwalOptions` property (`boolean`, default: `true`)
- When `animation` is set to `false`, a `swal-modal--no-animation` CSS class is added to the modal
- Added CSS rule that disables all animations (modal entrance, icon animations) when this class is present

### Usage
```javascript
swal({
  title: "No animation",
  text: "This modal appears without any animation",
  animation: false
});
```

### Changes
- `src/modules/options/index.ts` - Added `animation` to `SwalOptions` interface and defaults
- `src/modules/init/modal.ts` - Apply no-animation class when `animation: false`
- `src/sweetalert.css` - CSS rule to disable animations
- `src/modules/options/deprecations.ts` - Updated deprecation entry with docs link